### PR TITLE
Reset board before `set_fen_position`

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -99,6 +99,7 @@ class Stockfish:
         )
 
     def set_fen_position(self, fen_position: str) -> None:
+        self.__start_new_game()
         self.__put("position fen " + fen_position)
 
     def get_best_move(self) -> Optional[str]:

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -28,6 +28,16 @@ class TestStockfish:
         assert stockfish.is_move_correct("f4f5") is True
         assert stockfish.is_move_correct("a1c1") is False
 
+    def test_set_fen_position_reset(self, stockfish):
+        stockfish.set_fen_position(
+            "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"
+        )
+        stockfish.set_fen_position(
+            "3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53"
+        )
+        assert stockfish.is_move_correct("d5a8") is True
+        assert stockfish.is_move_correct("f2a2") is False
+
     def test_is_move_correct_first_move(self, stockfish):
         assert stockfish.is_move_correct("e2e1") is False
         assert stockfish.is_move_correct("a2a3") is True

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -32,9 +32,7 @@ class TestStockfish:
         stockfish.set_fen_position(
             "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"
         )
-        stockfish.set_fen_position(
-            "3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53"
-        )
+        stockfish.set_fen_position("3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53")
         assert stockfish.is_move_correct("d5a8") is True
         assert stockfish.is_move_correct("f2a2") is False
 


### PR DESCRIPTION
This PR makes `set_fen_position` reset the board before setting the FEN position. As per the UCI protocol, this should be done by putting `ucinewgame` to the engine.

This closes #13 .

I've also included a test for this. Please let me know if you want anything else!