### PR TITLE
Added get_top_moves function

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ stockfish.is_move_correct('a2a3')
 True
 ```
 
+### Get info on the top n moves
+```python
+stockfish.get_top_moves(3)
+```
+```text
+[{'Move': 'f5h7', 'Centipawn': None, 'Mate': 1}, {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None}, {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}]
+```
+
 ### Set current engine's skill level (ignoring ELO rating):
 ```python
 stockfish.set_skill_level(15)

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -296,7 +296,7 @@ class Stockfish:
         """
         
         if num_top_moves > self._parameters["MultiPV"] or num_top_moves <= 0:
-            raise ValueError('bad value for num_top_moves')
+            raise ValueError("num_top_moves is either greater than MultiPV or not a positive number.")
         self._go()
         lines = []
         while True:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -280,7 +280,7 @@ class Stockfish:
             elif splitted_text[0] == "bestmove":
                 return evaluation
     
-    def get_top_moves(self, num_top_moves: int) -> dict:
+    def get_top_moves(self, num_top_moves: int) -> List[dict]:
         """Returns info on the top moves/PVs in the position.
         
         Args:
@@ -289,10 +289,9 @@ class Stockfish:
                 those many legal moves. num_top_moves must not exceed the MultiPV parameter.
         
         Returns:
-            A dictionary where the keys are the PV number, and the values
-            are sub-dictionaries with keys for Move, Centipawn, and Mate. The corresponding
-            value for either Centipawn or Mate will be None.
-            If there are no moves in the position, None is returned.
+            A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate; 
+            the corresponding value for either the Centipawn or Mate key will be None.
+            If there are no moves in the position, an empty list is returned.
         """
         
         if num_top_moves > self._parameters["MultiPV"] or num_top_moves <= 0:
@@ -305,12 +304,12 @@ class Stockfish:
             lines.append(splitted_text)
             if splitted_text[0] == "bestmove":
                 break
-        first_moves_of_PVs = {}
+        top_moves = []
         multiplier = 1 if ("w" in self.get_fen_position()) else -1
         for current_line in reversed(lines):
             if current_line[0] == "bestmove":
                 if current_line[1] == "(none)":
-                    return None
+                    return []
             elif (("multipv" in current_line) and ("depth" in current_line) and 
                   current_line[current_line.index("depth") + 1] == self.depth):
                 multiPV_number = int(current_line[current_line.index("multipv") + 1])
@@ -319,13 +318,13 @@ class Stockfish:
                     has_mate_value = ("mate" in current_line)
                     if has_centipawn_value == has_mate_value:
                         raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
-                    first_moves_of_PVs[multiPV_number] = {
+                    top_moves.insert(0, {
                         "Move": current_line[current_line.index("pv") + 1],
                         "Centipawn": int(current_line[current_line.index("cp") + 1]) * multiplier if has_centipawn_value else None,
                         "Mate": int(current_line[current_line.index("mate") + 1]) * multiplier if has_mate_value else None
-                    }
+                    })
             else:
-                return first_moves_of_PVs
+                return top_moves
         raise RuntimeError("Reached the end of get_top_moves without returning anything.")
 
     def set_depth(self, depth_value: int = 2) -> None:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -7,6 +7,7 @@
 
 import subprocess
 from typing import Any, List, Optional
+import copy
 
 
 class Stockfish:
@@ -44,7 +45,7 @@ class Stockfish:
 
         if parameters is None:
             parameters = {}
-        self._parameters = self.default_stockfish_params
+        self._parameters = copy.deepcopy(self.default_stockfish_params)
         self._parameters.update(parameters)
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
@@ -65,7 +66,7 @@ class Stockfish:
         Returns:
             None
         """
-        self._parameters = self.default_stockfish_params
+        self._parameters = copy.deepcopy(self.default_stockfish_params)
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -286,7 +286,7 @@ class Stockfish:
         Args:
             num_top_moves:
                 The number of moves to return info on, assuming there are at least
-                those many legal moves.
+                those many legal moves. num_top_moves must not exceed the MultiPV parameter.
         
         Returns:
             A dictionary where the keys are the PV number, and the values
@@ -313,8 +313,8 @@ class Stockfish:
                     return None
             elif (("multipv" in current_line) and ("depth" in current_line) and 
                   current_line[current_line.index("depth") + 1] == self.depth):
-                multiPV_number = current_line[current_line.index("multipv") + 1]
-                if int(multiPV_number) <= num_top_moves:
+                multiPV_number = int(current_line[current_line.index("multipv") + 1])
+                if multiPV_number <= num_top_moves:
                     has_centipawn_value = ("cp" in current_line)
                     has_mate_value = ("mate" in current_line)
                     if has_centipawn_value == has_mate_value:
@@ -322,9 +322,7 @@ class Stockfish:
                     first_moves_of_PVs[multiPV_number] = {
                         "Move": current_line[current_line.index("pv") + 1],
                         "Centipawn": int(current_line[current_line.index("cp") + 1]) * multiplier if has_centipawn_value else None,
-                        "Mate": int(current_line[current_line.index("mate") + 1]) * multiplier if has_mate_value else None,
-                        "Depth": int(current_line[current_line.index("depth") + 1]),
-                        "Seldepth": int(current_line[current_line.index("seldepth") + 1])
+                        "Mate": int(current_line[current_line.index("mate") + 1]) * multiplier if has_mate_value else None
                     }
             else:
                 return first_moves_of_PVs

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -308,7 +308,7 @@ class Stockfish:
             lines.append(splitted_text)
             if splitted_text[0] == "bestmove":
                 break
-        top_moves = []
+        top_moves: List[dict] = []
         multiplier = 1 if ("w" in self.get_fen_position()) else -1
         for current_line in reversed(lines):
             if current_line[0] == "bestmove":

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -279,17 +279,17 @@ class Stockfish:
                         }
             elif splitted_text[0] == "bestmove":
                 return evaluation
-    
+
     def get_top_moves(self, num_top_moves: int = 5) -> List[dict]:
         """Returns info on the top moves in the position.
-        
+
         Args:
             num_top_moves:
                 The number of moves to return info on, assuming there are at least
                 those many legal moves.
-        
+
         Returns:
-            A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate; 
+            A list of dictionaries. In each dictionary, there are keys for Move, Centipawn, and Mate;
             the corresponding value for either the Centipawn or Mate key will be None.
             If there are no moves in the position, an empty list is returned.
         """
@@ -315,19 +315,33 @@ class Stockfish:
                 if current_line[1] == "(none)":
                     top_moves = []
                     break
-            elif (("multipv" in current_line) and ("depth" in current_line) and 
-                  current_line[current_line.index("depth") + 1] == self.depth):
+            elif (
+                ("multipv" in current_line)
+                and ("depth" in current_line)
+                and current_line[current_line.index("depth") + 1] == self.depth
+            ):
                 multiPV_number = int(current_line[current_line.index("multipv") + 1])
                 if multiPV_number <= num_top_moves:
-                    has_centipawn_value = ("cp" in current_line)
-                    has_mate_value = ("mate" in current_line)
+                    has_centipawn_value = "cp" in current_line
+                    has_mate_value = "mate" in current_line
                     if has_centipawn_value == has_mate_value:
-                        raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
-                    top_moves.insert(0, {
-                        "Move": current_line[current_line.index("pv") + 1],
-                        "Centipawn": int(current_line[current_line.index("cp") + 1]) * multiplier if has_centipawn_value else None,
-                        "Mate": int(current_line[current_line.index("mate") + 1]) * multiplier if has_mate_value else None
-                    })
+                        raise RuntimeError(
+                            "Having a centipawn value and mate value should be mutually exclusive."
+                        )
+                    top_moves.insert(
+                        0,
+                        {
+                            "Move": current_line[current_line.index("pv") + 1],
+                            "Centipawn": int(current_line[current_line.index("cp") + 1])
+                            * multiplier
+                            if has_centipawn_value
+                            else None,
+                            "Mate": int(current_line[current_line.index("mate") + 1])
+                            * multiplier
+                            if has_mate_value
+                            else None,
+                        },
+                    )
             else:
                 break
         if old_MultiPV_value != self._parameters["MultiPV"]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -279,6 +279,56 @@ class Stockfish:
                         }
             elif splitted_text[0] == "bestmove":
                 return evaluation
+    
+    def get_top_moves(self, num_top_moves: int) -> dict:
+        """Returns info on the top moves/PVs in the position.
+        
+        Args:
+            num_top_moves:
+                The number of moves to return info on, assuming there are at least
+                those many legal moves.
+        
+        Returns:
+            A dictionary where the keys are the PV number, and the values
+            are sub-dictionaries with keys for Move, Centipawn, and Mate. The corresponding
+            value for either Centipawn or Mate will be None.
+            If there are no moves in the position, None is returned.
+        """
+        
+        if num_top_moves > self._parameters["MultiPV"] or num_top_moves <= 0:
+            raise ValueError('bad value for num_top_moves')
+        self._go()
+        lines = []
+        while True:
+            text = self._read_line()
+            splitted_text = text.split(" ")
+            lines.append(splitted_text)
+            if splitted_text[0] == "bestmove":
+                break
+        first_moves_of_PVs = {}
+        multiplier = 1 if ("w" in self.get_fen_position()) else -1
+        for current_line in reversed(lines):
+            if current_line[0] == "bestmove":
+                if current_line[1] == "(none)":
+                    return None
+            elif (("multipv" in current_line) and ("depth" in current_line) and 
+                  current_line[current_line.index("depth") + 1] == self.depth):
+                multiPV_number = current_line[current_line.index("multipv") + 1]
+                if int(multiPV_number) <= num_top_moves:
+                    has_centipawn_value = ("cp" in current_line)
+                    has_mate_value = ("mate" in current_line)
+                    if has_centipawn_value == has_mate_value:
+                        raise RuntimeError("Having a centipawn value and mate value should be mutually exclusive.")
+                    first_moves_of_PVs[multiPV_number] = {
+                        "Move": current_line[current_line.index("pv") + 1],
+                        "Centipawn": int(current_line[current_line.index("cp") + 1]) * multiplier if has_centipawn_value else None,
+                        "Mate": int(current_line[current_line.index("mate") + 1]) * multiplier if has_mate_value else None,
+                        "Depth": int(current_line[current_line.index("depth") + 1]),
+                        "Seldepth": int(current_line[current_line.index("seldepth") + 1])
+                    }
+            else:
+                return first_moves_of_PVs
+        raise RuntimeError("Reached the end of get_top_moves without returning anything.")
 
     def set_depth(self, depth_value: int = 2) -> None:
         """Sets current depth of stockfish engine.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -270,3 +270,33 @@ class TestStockfish:
         arg1 = s1.get_parameters()
         arg2 = s2.get_parameters()
         assert arg1 != arg2
+
+    def test_get_top_moves(self):
+        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 3})
+        stockfish.set_fen_position("b5k1/1q3p1p/6p1/8/8/2Q3P1/1B3P1P/6K1 w - - 0 1")
+        top_moves = stockfish.get_top_moves(3)
+        assert ((top_moves[1]["Move"] == "c3g7" and top_moves[2]["Move"] == "c3h8") or
+               (top_moves[1]["Move"] == "c3h8" and top_moves[2]["Move"] == "c3g7"))
+        assert top_moves[3]["Move"] == "f2f3" or top_moves[3]["Move"] == "g1f1"
+        assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
+        assert top_moves[2]["Centipawn"] == None and top_moves[2]["Mate"] == 1
+        assert top_moves[3]["Centipawn"] == 0 and top_moves[3]["Mate"] == None
+    
+    def test_get_top_moves_mate(self):
+        stockfish = Stockfish(depth = 10, parameters = {"MultiPV": 3})
+        stockfish.set_fen_position("8/8/8/8/8/6k1/8/3r2K1 w - - 0 1")
+        assert stockfish.get_top_moves(2) == None
+    
+    def test_get_top_moves_raising_error(self):
+        stockfish = Stockfish()
+        num_errors_raised = 0
+        stockfish.set_fen_position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        try:
+            print(stockfish.get_top_moves(0))
+        except ValueError:
+            num_errors_raised += 1
+        try:
+            print(stockfish.get_top_moves(2))
+        except ValueError:
+            num_errors_raised += 1 # error should be raised since MultiPV = 1
+        assert num_errors_raised == 2

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -272,21 +272,19 @@ class TestStockfish:
         assert arg1 != arg2
 
     def test_get_top_moves(self):
-        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 2})
-        stockfish.set_fen_position("b5k1/1q3p1p/6p1/8/8/2Q3P1/1B3P1P/6K1 w - - 0 1")
-        top_moves = stockfish.get_top_moves()
-        assert ((top_moves[0]["Move"] == "c3g7" and top_moves[1]["Move"] == "c3h8") or
-               (top_moves[0]["Move"] == "c3h8" and top_moves[1]["Move"] == "c3g7"))
-        assert top_moves[2]["Move"] == "f2f3" or top_moves[2]["Move"] == "g1f1"
-        assert top_moves[0]["Centipawn"] == None and top_moves[0]["Mate"] == 1
-        assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
-        assert top_moves[2]["Centipawn"] < 50 and top_moves[2]["Mate"] == None
-        assert len(top_moves) == 5
+        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 4})
+        stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
+        assert stockfish.get_top_moves(2) == [{"Move": "e1e8", "Centipawn": None, "Mate": 1},
+                                              {"Move": "c8e8", "Centipawn": None, "Mate": 2}]
+        stockfish.set_fen_position("8/8/8/8/8/3r2k1/8/6K1 w - - 0 1")
+        assert stockfish.get_top_moves(2) == [{"Move": "g1f1", "Centipawn": None, "Mate": -2},
+                                              {"Move": "g1h1", "Centipawn": None, "Mate": -1}]
     
     def test_get_top_moves_mate(self):
         stockfish = Stockfish(depth = 10, parameters = {"MultiPV": 3})
         stockfish.set_fen_position("8/8/8/8/8/6k1/8/3r2K1 w - - 0 1")
-        assert stockfish.get_top_moves(2) == []
+        assert stockfish.get_top_moves() == []
+        assert stockfish.get_parameters()["MultiPV"] == 3
     
     def test_get_top_moves_raising_error(self):
         stockfish = Stockfish()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -292,11 +292,11 @@ class TestStockfish:
         num_errors_raised = 0
         stockfish.set_fen_position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
         try:
-            print(stockfish.get_top_moves(0))
+            stockfish.get_top_moves(0)
         except ValueError:
             num_errors_raised += 1
         try:
-            print(stockfish.get_top_moves(2))
+            stockfish.get_top_moves(2)
         except ValueError:
             num_errors_raised += 1 # error should be raised since MultiPV = 1
         assert num_errors_raised == 2

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -272,31 +272,37 @@ class TestStockfish:
         assert arg1 != arg2
 
     def test_get_top_moves(self):
-        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 4})
+        stockfish = Stockfish(depth=15, parameters={"MultiPV": 4})
         stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
-        assert stockfish.get_top_moves(2) == [{"Move": "e1e8", "Centipawn": None, "Mate": 1},
-                                              {"Move": "c8e8", "Centipawn": None, "Mate": 2}]
+        assert stockfish.get_top_moves(2) == [
+            {"Move": "e1e8", "Centipawn": None, "Mate": 1},
+            {"Move": "c8e8", "Centipawn": None, "Mate": 2},
+        ]
         stockfish.set_fen_position("8/8/8/8/8/3r2k1/8/6K1 w - - 0 1")
-        assert stockfish.get_top_moves(2) == [{"Move": "g1f1", "Centipawn": None, "Mate": -2},
-                                              {"Move": "g1h1", "Centipawn": None, "Mate": -1}]
-    
+        assert stockfish.get_top_moves(2) == [
+            {"Move": "g1f1", "Centipawn": None, "Mate": -2},
+            {"Move": "g1h1", "Centipawn": None, "Mate": -1},
+        ]
+
     def test_get_top_moves_mate(self):
-        stockfish = Stockfish(depth = 10, parameters = {"MultiPV": 3})
+        stockfish = Stockfish(depth=10, parameters={"MultiPV": 3})
         stockfish.set_fen_position("8/8/8/8/8/6k1/8/3r2K1 w - - 0 1")
         assert stockfish.get_top_moves() == []
         assert stockfish.get_parameters()["MultiPV"] == 3
-    
+
     def test_get_top_moves_raising_error(self):
         stockfish = Stockfish()
-        stockfish.set_fen_position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        stockfish.set_fen_position(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        )
         raised_error = False
         try:
             stockfish.get_top_moves(0)
         except ValueError:
             raised_error = True
-        assert(raised_error)
+        assert raised_error
         try:
             stockfish.get_top_moves(2)
         except ValueError:
-            assert(False) # Error should not be raised this time.
+            assert False  # Error should not be raised this time.
         assert stockfish.get_parameters()["MultiPV"] == 1

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -280,7 +280,7 @@ class TestStockfish:
         assert top_moves[2]["Move"] == "f2f3" or top_moves[2]["Move"] == "g1f1"
         assert top_moves[0]["Centipawn"] == None and top_moves[0]["Mate"] == 1
         assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
-        assert top_moves[2]["Centipawn"] < 0.5 and top_moves[2]["Mate"] == None
+        assert top_moves[2]["Centipawn"] < 50 and top_moves[2]["Mate"] == None
         assert len(top_moves) == 5
     
     def test_get_top_moves_mate(self):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -280,7 +280,7 @@ class TestStockfish:
         assert top_moves[2]["Move"] == "f2f3" or top_moves[2]["Move"] == "g1f1"
         assert top_moves[0]["Centipawn"] == None and top_moves[0]["Mate"] == 1
         assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
-        assert top_moves[2]["Centipawn"] == 0 and top_moves[2]["Mate"] == None
+        assert top_moves[2]["Centipawn"] < 0.5 and top_moves[2]["Mate"] == None
         assert len(top_moves) == 5
     
     def test_get_top_moves_mate(self):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -275,17 +275,17 @@ class TestStockfish:
         stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 3})
         stockfish.set_fen_position("b5k1/1q3p1p/6p1/8/8/2Q3P1/1B3P1P/6K1 w - - 0 1")
         top_moves = stockfish.get_top_moves(3)
-        assert ((top_moves[1]["Move"] == "c3g7" and top_moves[2]["Move"] == "c3h8") or
-               (top_moves[1]["Move"] == "c3h8" and top_moves[2]["Move"] == "c3g7"))
-        assert top_moves[3]["Move"] == "f2f3" or top_moves[3]["Move"] == "g1f1"
+        assert ((top_moves[0]["Move"] == "c3g7" and top_moves[1]["Move"] == "c3h8") or
+               (top_moves[0]["Move"] == "c3h8" and top_moves[1]["Move"] == "c3g7"))
+        assert top_moves[2]["Move"] == "f2f3" or top_moves[2]["Move"] == "g1f1"
+        assert top_moves[0]["Centipawn"] == None and top_moves[0]["Mate"] == 1
         assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
-        assert top_moves[2]["Centipawn"] == None and top_moves[2]["Mate"] == 1
-        assert top_moves[3]["Centipawn"] == 0 and top_moves[3]["Mate"] == None
+        assert top_moves[2]["Centipawn"] == 0 and top_moves[2]["Mate"] == None
     
     def test_get_top_moves_mate(self):
         stockfish = Stockfish(depth = 10, parameters = {"MultiPV": 3})
         stockfish.set_fen_position("8/8/8/8/8/6k1/8/3r2K1 w - - 0 1")
-        assert stockfish.get_top_moves(2) == None
+        assert stockfish.get_top_moves(2) == []
     
     def test_get_top_moves_raising_error(self):
         stockfish = Stockfish()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -295,14 +295,7 @@ class TestStockfish:
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         )
-        raised_error = False
-        try:
+        with pytest.raises(ValueError):
             stockfish.get_top_moves(0)
-        except ValueError:
-            raised_error = True
-        assert raised_error
-        try:
-            stockfish.get_top_moves(2)
-        except ValueError:
-            assert False  # Error should not be raised this time.
+        assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -272,15 +272,16 @@ class TestStockfish:
         assert arg1 != arg2
 
     def test_get_top_moves(self):
-        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 3})
+        stockfish = Stockfish(depth = 15, parameters = {"MultiPV": 2})
         stockfish.set_fen_position("b5k1/1q3p1p/6p1/8/8/2Q3P1/1B3P1P/6K1 w - - 0 1")
-        top_moves = stockfish.get_top_moves(3)
+        top_moves = stockfish.get_top_moves()
         assert ((top_moves[0]["Move"] == "c3g7" and top_moves[1]["Move"] == "c3h8") or
                (top_moves[0]["Move"] == "c3h8" and top_moves[1]["Move"] == "c3g7"))
         assert top_moves[2]["Move"] == "f2f3" or top_moves[2]["Move"] == "g1f1"
         assert top_moves[0]["Centipawn"] == None and top_moves[0]["Mate"] == 1
         assert top_moves[1]["Centipawn"] == None and top_moves[1]["Mate"] == 1
         assert top_moves[2]["Centipawn"] == 0 and top_moves[2]["Mate"] == None
+        assert len(top_moves) == 5
     
     def test_get_top_moves_mate(self):
         stockfish = Stockfish(depth = 10, parameters = {"MultiPV": 3})
@@ -289,14 +290,15 @@ class TestStockfish:
     
     def test_get_top_moves_raising_error(self):
         stockfish = Stockfish()
-        num_errors_raised = 0
         stockfish.set_fen_position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        raised_error = False
         try:
             stockfish.get_top_moves(0)
         except ValueError:
-            num_errors_raised += 1
+            raised_error = True
+        assert(raised_error)
         try:
             stockfish.get_top_moves(2)
         except ValueError:
-            num_errors_raised += 1 # error should be raised since MultiPV = 1
-        assert num_errors_raised == 2
+            assert(False) # Error should not be raised this time.
+        assert stockfish.get_parameters()["MultiPV"] == 1


### PR DESCRIPTION
This PR adds the get_top_moves function, which gives info on Stockfish's top PVs. It returns a dictionary where each PV has an entry. An entry's key is the PV number, and the value is another dictionary storing the first move of the PV and the evaluation info.

self._parameters is also assigned to a deep copy of self.default_stockfish_params, which prevents the latter from being modified when self._parameters.update(parameters) happens.