### PR TITLE
Make moves from the current position

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 
 ### Set position by Forsyth–Edwards Notation (FEN):
 ```python
-stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
+stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2", True)
 ```
 
 ### Get best move

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ stockfish = Stockfish(parameters={"Threads": 2, "Minimum Thinking Time": 30})
 stockfish.set_position(["e2e4", "e7e6"])
 ```
 
+### Set position by sequence of moves from the current position:
+```python
+stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
+```
+
 ### Set position by Forsyth–Edwards Notation (FEN):
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ stockfish = Stockfish(parameters={"Threads": 2, "Minimum Thinking Time": 30})
 stockfish.set_position(["e2e4", "e7e6"])
 ```
 
-### Set position by sequence of moves from the current position:
+### Update position by making a sequence of moves from the current position:
 ```python
 stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 
 ### Set position by Forsyth–Edwards Notation (FEN):
 ```python
-stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2", True)
+stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
 ```
 
 ### Get best move

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -70,10 +70,14 @@ class Stockfish:
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 
-    def _start_new_game(self) -> None:
-        self._put("ucinewgame")
+    def _prep_for_new_position(self, do_ucinewgame: bool) -> None:
+        if do_ucinewgame:
+            self._put("ucinewgame")
         self._is_ready()
         self.info = ""
+
+    def _start_new_game(self) -> None:
+        self._prep_for_new_position(True)
 
     def _put(self, command: str) -> None:
         if not self.stockfish.stdin:
@@ -136,8 +140,7 @@ class Stockfish:
             raise ValueError(
                 "No moves sent in to the make_moves_from_current_position function."
             )
-        self._is_ready()
-        self.info = ""
+        self._prep_for_new_position(False)
         self._put(
             f"position fen {self.get_fen_position()} moves {self._convert_move_list_to_str(moves)}"
         )
@@ -208,12 +211,7 @@ class Stockfish:
         Returns:
             None
         """
-        if reset_TT:
-            self._start_new_game()
-        else:
-            self._is_ready()
-            self.info = ""
-            # Same behaviour as start_new_game, except without the self._put("ucinewgame") call.
+        self._prep_for_new_position(reset_TT)
         self._put(f"position fen {fen_position}")
 
     def get_best_move(self) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -122,10 +122,10 @@ class Stockfish:
         if moves is None:
             moves = []
         self._put(f"position startpos moves {self._convert_move_list_to_str(moves)}")
-    
+
     def make_moves_from_current_position(self, moves: List[str]) -> None:
         """Sets the board position by making the moves from the current position.
-        
+
         Args:
             moves:
               A list of moves to play in the current position, in order to reach a new position.
@@ -133,10 +133,14 @@ class Stockfish:
               Example: ['g4d7', 'a8b8', 'f1d1']
         """
         if moves == []:
-            raise ValueError("No moves sent in to the make_moves_from_current_position function.")
+            raise ValueError(
+                "No moves sent in to the make_moves_from_current_position function."
+            )
         fen_position = self.get_fen_position()
         self._start_new_game()
-        self._put(f"position fen {fen_position} moves {self._convert_move_list_to_str(moves)}")
+        self._put(
+            f"position fen {fen_position} moves {self._convert_move_list_to_str(moves)}"
+        )
 
     def get_board_visual(self) -> str:
         """Returns a visual representation of the current board position.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -50,7 +50,7 @@ class Stockfish:
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 
-        self._prep_for_new_position(True)
+        self._prepare_for_new_position(True)
 
     def get_parameters(self) -> dict:
         """Returns current board position.
@@ -70,7 +70,7 @@ class Stockfish:
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 
-    def _prep_for_new_position(self, do_ucinewgame: bool) -> None:
+    def _prepare_for_new_position(self, do_ucinewgame: bool = True) -> None:
         if do_ucinewgame:
             self._put("ucinewgame")
         self._is_ready()
@@ -119,7 +119,7 @@ class Stockfish:
               Must be in full algebraic notation.
               example: ['e2e4', 'e7e5']
         """
-        self._prep_for_new_position(True)
+        self._prepare_for_new_position(True)
         if moves is None:
             moves = []
         self._put(f"position startpos moves {self._convert_move_list_to_str(moves)}")
@@ -137,7 +137,7 @@ class Stockfish:
             raise ValueError(
                 "No moves sent in to the make_moves_from_current_position function."
             )
-        self._prep_for_new_position(False)
+        self._prepare_for_new_position(False)
         self._put(
             f"position fen {self.get_fen_position()} moves {self._convert_move_list_to_str(moves)}"
         )
@@ -199,7 +199,7 @@ class Stockfish:
         self._parameters.update({"UCI_Elo": elo_rating})
 
     def set_fen_position(
-        self, fen_position: str, reset_transposition_table: bool = True
+        self, fen_position: str, send_ucinewgame_token: bool = True
     ) -> None:
         """Sets current board position in Forsyth–Edwards notation (FEN).
 
@@ -207,10 +207,15 @@ class Stockfish:
             fen_position:
               FEN string of board position.
 
+            send_ucinewgame_token:
+              Whether to send the ucinewgame token to the Stockfish engine.
+              The most prominent effect this will have is clearing Stockfish's transposition table,
+              which should be done if the new position is unrelated to the current position.
+
         Returns:
             None
         """
-        self._prep_for_new_position(reset_transposition_table)
+        self._prepare_for_new_position(send_ucinewgame_token)
         self._put(f"position fen {fen_position}")
 
     def get_best_move(self) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -198,7 +198,9 @@ class Stockfish:
         self._set_option("UCI_Elo", elo_rating)
         self._parameters.update({"UCI_Elo": elo_rating})
 
-    def set_fen_position(self, fen_position: str, reset_TT: bool = True) -> None:
+    def set_fen_position(
+        self, fen_position: str, reset_transposition_table: bool = True
+    ) -> None:
         """Sets current board position in Forsyth–Edwards notation (FEN).
 
         Args:
@@ -208,7 +210,7 @@ class Stockfish:
         Returns:
             None
         """
-        self._prep_for_new_position(reset_TT)
+        self._prep_for_new_position(reset_transposition_table)
         self._put(f"position fen {fen_position}")
 
     def get_best_move(self) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -136,10 +136,9 @@ class Stockfish:
             raise ValueError(
                 "No moves sent in to the make_moves_from_current_position function."
             )
-        fen_position = self.get_fen_position()
-        self._start_new_game()
+        self._is_ready()
         self._put(
-            f"position fen {fen_position} moves {self._convert_move_list_to_str(moves)}"
+            f"position fen {self.get_fen_position()} moves {self._convert_move_list_to_str(moves)}"
         )
 
     def get_board_visual(self) -> str:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -124,13 +124,13 @@ class Stockfish:
         self._put(f"position startpos moves {self._convert_move_list_to_str(moves)}")
 
     def make_moves_from_current_position(self, moves: List[str]) -> None:
-        """Sets the board position by making the moves from the current position.
+        """Sets a new position by playing the moves from the current position.
 
         Args:
             moves:
               A list of moves to play in the current position, in order to reach a new position.
               Must be in full algebraic notation.
-              Example: ['g4d7', 'a8b8', 'f1d1']
+              Example: ["g4d7", "a8b8", "f1d1"]
         """
         if moves == []:
             raise ValueError(

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -137,6 +137,7 @@ class Stockfish:
                 "No moves sent in to the make_moves_from_current_position function."
             )
         self._is_ready()
+        self.info = ""
         self._put(
             f"position fen {self.get_fen_position()} moves {self._convert_move_list_to_str(moves)}"
         )

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -122,6 +122,21 @@ class Stockfish:
         if moves is None:
             moves = []
         self._put(f"position startpos moves {self._convert_move_list_to_str(moves)}")
+    
+    def make_moves_from_current_position(self, moves: List[str]) -> None:
+        """Sets the board position by making the moves from the current position.
+        
+        Args:
+            moves:
+              A list of moves to play in the current position, in order to reach a new position.
+              Must be in full algebraic notation.
+              Example: ['g4d7', 'a8b8', 'f1d1']
+        """
+        if moves == []:
+            raise ValueError("No moves sent in to the make_moves_from_current_position function.")
+        fen_position = self.get_fen_position()
+        self._start_new_game()
+        self._put(f"position fen {fen_position} moves {self._convert_move_list_to_str(moves)}")
 
     def get_board_visual(self) -> str:
         """Returns a visual representation of the current board position.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -197,7 +197,7 @@ class Stockfish:
         self._set_option("UCI_Elo", elo_rating)
         self._parameters.update({"UCI_Elo": elo_rating})
 
-    def set_fen_position(self, fen_position: str) -> None:
+    def set_fen_position(self, fen_position: str, reset_TT: bool = True) -> None:
         """Sets current board position in Forsyth–Edwards notation (FEN).
 
         Args:
@@ -207,7 +207,10 @@ class Stockfish:
         Returns:
             None
         """
-        self._start_new_game()
+        if reset_TT:
+            self._start_new_game()
+        else:
+            self._is_ready()
         self._put(f"position fen {fen_position}")
 
     def get_best_move(self) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -50,7 +50,7 @@ class Stockfish:
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 
-        self._start_new_game()
+        self._prep_for_new_position(True)
 
     def get_parameters(self) -> dict:
         """Returns current board position.
@@ -75,9 +75,6 @@ class Stockfish:
             self._put("ucinewgame")
         self._is_ready()
         self.info = ""
-
-    def _start_new_game(self) -> None:
-        self._prep_for_new_position(True)
 
     def _put(self, command: str) -> None:
         if not self.stockfish.stdin:
@@ -122,7 +119,7 @@ class Stockfish:
               Must be in full algebraic notation.
               example: ['e2e4', 'e7e5']
         """
-        self._start_new_game()
+        self._prep_for_new_position(True)
         if moves is None:
             moves = []
         self._put(f"position startpos moves {self._convert_move_list_to_str(moves)}")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -211,6 +211,8 @@ class Stockfish:
             self._start_new_game()
         else:
             self._is_ready()
+            self.info = ""
+            # Same behaviour as start_new_game, except without the self._put("ucinewgame") call.
         self._put(f"position fen {fen_position}")
 
     def get_best_move(self) -> Optional[str]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -70,8 +70,8 @@ class Stockfish:
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
 
-    def _prepare_for_new_position(self, do_ucinewgame: bool = True) -> None:
-        if do_ucinewgame:
+    def _prepare_for_new_position(self, send_ucinewgame_token: bool = True) -> None:
+        if send_ucinewgame_token:
             self._put("ucinewgame")
         self._is_ready()
         self.info = ""
@@ -208,7 +208,7 @@ class Stockfish:
               FEN string of board position.
 
             send_ucinewgame_token:
-              Whether to send the ucinewgame token to the Stockfish engine.
+              Whether to send the "ucinewgame" token to the Stockfish engine.
               The most prominent effect this will have is clearing Stockfish's transposition table,
               which should be done if the new position is unrelated to the current position.
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from timeit import default_timer
 
 from stockfish import Stockfish
 
@@ -326,3 +327,27 @@ class TestStockfish:
             stockfish.get_fen_position()
             == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
         )
+
+    def test_make_moves_TT_speed(self):
+        stockfish = Stockfish(depth=16)
+        positions_considered = []
+        stockfish.set_fen_position(
+            "rnbqkbnr/ppp1pppp/8/3p4/2PP4/8/PP2PPPP/RNBQKBNR b KQkq - 0 2"
+        )
+
+        total_time_calculating_first = 0.0
+        for i in range(5):
+            start = default_timer()
+            chosen_move = stockfish.get_best_move()
+            total_time_calculating_first += default_timer() - start
+            positions_considered.append(stockfish.get_fen_position())
+            stockfish.make_moves_from_current_position([chosen_move])
+
+        total_time_calculating_second = 0.0
+        for i in range(len(positions_considered)):
+            stockfish.set_fen_position(positions_considered[i])
+            start = default_timer()
+            stockfish.get_best_move()
+            total_time_calculating_second += default_timer() - start
+
+        assert total_time_calculating_first < total_time_calculating_second

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -353,14 +353,16 @@ class TestStockfish:
         )
 
     def test_make_moves_transposition_table_speed(self):
-        # make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
-        # will reach a new position similar to the current one. Meanwhile, set_fen_position will send this
-        # token (unless the user specifies otherwise), since it could be going to a completely new position.
+        """
+        make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
+        will reach a new position similar to the current one. Meanwhile, set_fen_position will send this
+        token (unless the user specifies otherwise), since it could be going to a completely new position.
 
-        # A big effect of sending this token is that it resets SF's transposition table. If the
-        # new position is similar to the current one, this will affect SF's speed. This function tests
-        # that make_moves_from_current_position doesn't reset the transposition table, by verifying SF is faster in
-        # evaluating a consecutive set of positions when the make_moves_from_current_position function is used.
+        A big effect of sending this token is that it resets SF's transposition table. If the
+        new position is similar to the current one, this will affect SF's speed. This function tests
+        that make_moves_from_current_position doesn't reset the transposition table, by verifying SF is faster in
+        evaluating a consecutive set of positions when the make_moves_from_current_position function is used.
+        """
 
         stockfish = Stockfish(depth=16)
         positions_considered = []

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -73,6 +73,11 @@ class TestStockfish:
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53")
         assert stockfish.info == ""
 
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52")
+        stockfish.get_best_move()
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53", False)
+        assert stockfish.info == ""
+
     def test_set_fen_position_starts_new_game(self, stockfish):
         stockfish.set_fen_position(
             "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -305,10 +305,6 @@ class TestStockfish:
         stockfish.set_fen_position(
             "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
         )
-        assert (
-            stockfish.get_fen_position()
-            == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
-        )
         with pytest.raises(ValueError):
             stockfish.make_moves_from_current_position([])
         stockfish.make_moves_from_current_position(["e1g1"])
@@ -324,26 +320,9 @@ class TestStockfish:
             == "r1bqkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNBQ1RK1 w kq - 1 5"
         )
         stockfish.make_moves_from_current_position(
-            ["d1d8", "e8d8", "b1c3", "d8e8", "f1d1", "f5e7"]
+            ["d1d8", "e8d8", "b1c3", "d8e8", "f1d1", "f5e7", "h2h3", "f7f5"]
         )
-        assert (
-            stockfish.get_fen_position()
-            == "r1b1kb1r/ppp1nppp/2p5/4P3/8/2N2N2/PPP2PPP/R1BR2K1 w - - 4 8"
-        )
-        stockfish.make_moves_from_current_position(["h2h3", "f7f5"])
         assert (
             stockfish.get_fen_position()
             == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
-        )
-        stockfish.make_moves_from_current_position(["e5f6"])
-        assert (
-            stockfish.get_fen_position()
-            == "r1b1kb1r/ppp1n1pp/2p2P2/8/8/2N2N1P/PPP2PP1/R1BR2K1 b - - 0 9"
-        )
-        stockfish.set_fen_position(
-            "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"
-        )
-        assert (
-            stockfish.get_fen_position()
-            == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"
         )

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -82,6 +82,21 @@ class TestStockfish:
         stockfish.set_fen_position("3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53")
         assert stockfish.info == ""
 
+    def test_set_fen_position_second_argument(self):
+        stockfish = Stockfish(depth=16)
+        stockfish.set_fen_position(
+            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", True
+        )
+        assert stockfish.get_best_move() == "e4e5"
+        stockfish.set_fen_position(
+            "rnbqk2r/pppp1ppp/3bpn2/4P3/3P4/2N5/PPP2PPP/R1BQKBNR b KQkq - 0 1", False
+        )
+        assert stockfish.get_best_move() == "d6e7"
+        stockfish.set_fen_position(
+            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", False
+        )
+        assert stockfish.get_best_move() == "e4e5"
+
     def test_is_move_correct_first_move(self, stockfish):
         assert stockfish.is_move_correct("e2e1") is False
         assert stockfish.is_move_correct("a2a3") is True

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -299,3 +299,22 @@ class TestStockfish:
             stockfish.get_top_moves(0)
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
+    
+    def test_make_moves(self):
+        stockfish = Stockfish()
+        stockfish.set_fen_position("r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1")
+        assert stockfish.get_fen_position() == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
+        with pytest.raises(ValueError):
+            stockfish.make_moves_from_current_position([])
+        stockfish.make_moves_from_current_position(['e1g1'])
+        assert stockfish.get_fen_position() == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 1"
+        stockfish.make_moves_from_current_position(['f6e4', 'd2d4', 'e4d6', 'b5c6', 'd7c6', 'd4e5', 'd6f5'])
+        assert stockfish.get_fen_position() == "r1bqkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNBQ1RK1 w kq - 1 5"
+        stockfish.make_moves_from_current_position(['d1d8', 'e8d8', 'b1c3', 'd8e8', 'f1d1', 'f5e7'])
+        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1nppp/2p5/4P3/8/2N2N2/PPP2PPP/R1BR2K1 w - - 4 8"
+        stockfish.make_moves_from_current_position(['h2h3', 'f7f5'])
+        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
+        stockfish.make_moves_from_current_position(['e5f6'])
+        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p2P2/8/8/2N2N1P/PPP2PP1/R1BR2K1 b - - 0 9"
+        stockfish.set_fen_position("r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1")
+        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -300,7 +300,7 @@ class TestStockfish:
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
 
-    def test_make_moves(self):
+    def test_make_moves_from_current_position(self):
         stockfish = Stockfish()
         stockfish.set_fen_position(
             "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -93,10 +93,12 @@ class TestStockfish:
             "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", True
         )
         assert stockfish.get_best_move() == "e4e5"
+
         stockfish.set_fen_position(
             "rnbqk2r/pppp1ppp/3bpn2/4P3/3P4/2N5/PPP2PPP/R1BQKBNR b KQkq - 0 1", False
         )
         assert stockfish.get_best_move() == "d6e7"
+
         stockfish.set_fen_position(
             "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", False
         )
@@ -321,18 +323,19 @@ class TestStockfish:
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
 
-    def test_make_moves_from_current_position(self):
-        stockfish = Stockfish()
+    def test_make_moves_from_current_position(self, stockfish):
         stockfish.set_fen_position(
             "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
         )
         with pytest.raises(ValueError):
             stockfish.make_moves_from_current_position([])
+
         stockfish.make_moves_from_current_position(["e1g1"])
         assert (
             stockfish.get_fen_position()
             == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 1"
         )
+
         stockfish.make_moves_from_current_position(
             ["f6e4", "d2d4", "e4d6", "b5c6", "d7c6", "d4e5", "d6f5"]
         )
@@ -340,6 +343,7 @@ class TestStockfish:
             stockfish.get_fen_position()
             == "r1bqkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNBQ1RK1 w kq - 1 5"
         )
+
         stockfish.make_moves_from_current_position(
             ["d1d8", "e8d8", "b1c3", "d8e8", "f1d1", "f5e7", "h2h3", "f7f5"]
         )
@@ -348,7 +352,16 @@ class TestStockfish:
             == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
         )
 
-    def test_make_moves_TT_speed(self):
+    def test_make_moves_transposition_table_speed(self):
+        # make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
+        # will reach a new position similar to the current one. Meanwhile, set_fen_position will send this
+        # token (unless the user specifies otherwise), since it could be going to a completely new position.
+
+        # A big effect of sending this token is that it resets SF's transposition table. If the
+        # new position is similar to the current one, this will affect SF's speed. This function tests
+        # that make_moves_from_current_position doesn't reset the transposition table, by verifying SF is faster in
+        # evaluating a consecutive set of positions when the make_moves_from_current_position function is used.
+
         stockfish = Stockfish(depth=16)
         positions_considered = []
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -299,22 +299,51 @@ class TestStockfish:
             stockfish.get_top_moves(0)
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_parameters()["MultiPV"] == 1
-    
+
     def test_make_moves(self):
         stockfish = Stockfish()
-        stockfish.set_fen_position("r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1")
-        assert stockfish.get_fen_position() == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
+        stockfish.set_fen_position(
+            "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
+        )
+        assert (
+            stockfish.get_fen_position()
+            == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
+        )
         with pytest.raises(ValueError):
             stockfish.make_moves_from_current_position([])
-        stockfish.make_moves_from_current_position(['e1g1'])
-        assert stockfish.get_fen_position() == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 1"
-        stockfish.make_moves_from_current_position(['f6e4', 'd2d4', 'e4d6', 'b5c6', 'd7c6', 'd4e5', 'd6f5'])
-        assert stockfish.get_fen_position() == "r1bqkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNBQ1RK1 w kq - 1 5"
-        stockfish.make_moves_from_current_position(['d1d8', 'e8d8', 'b1c3', 'd8e8', 'f1d1', 'f5e7'])
-        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1nppp/2p5/4P3/8/2N2N2/PPP2PPP/R1BR2K1 w - - 4 8"
-        stockfish.make_moves_from_current_position(['h2h3', 'f7f5'])
-        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
-        stockfish.make_moves_from_current_position(['e5f6'])
-        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p2P2/8/8/2N2N1P/PPP2PP1/R1BR2K1 b - - 0 9"
-        stockfish.set_fen_position("r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1")
-        assert stockfish.get_fen_position() == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"
+        stockfish.make_moves_from_current_position(["e1g1"])
+        assert (
+            stockfish.get_fen_position()
+            == "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 1"
+        )
+        stockfish.make_moves_from_current_position(
+            ["f6e4", "d2d4", "e4d6", "b5c6", "d7c6", "d4e5", "d6f5"]
+        )
+        assert (
+            stockfish.get_fen_position()
+            == "r1bqkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNBQ1RK1 w kq - 1 5"
+        )
+        stockfish.make_moves_from_current_position(
+            ["d1d8", "e8d8", "b1c3", "d8e8", "f1d1", "f5e7"]
+        )
+        assert (
+            stockfish.get_fen_position()
+            == "r1b1kb1r/ppp1nppp/2p5/4P3/8/2N2N2/PPP2PPP/R1BR2K1 w - - 4 8"
+        )
+        stockfish.make_moves_from_current_position(["h2h3", "f7f5"])
+        assert (
+            stockfish.get_fen_position()
+            == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - f6 0 9"
+        )
+        stockfish.make_moves_from_current_position(["e5f6"])
+        assert (
+            stockfish.get_fen_position()
+            == "r1b1kb1r/ppp1n1pp/2p2P2/8/8/2N2N1P/PPP2PP1/R1BR2K1 b - - 0 9"
+        )
+        stockfish.set_fen_position(
+            "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"
+        )
+        assert (
+            stockfish.get_fen_position()
+            == "r1b1kb1r/ppp1n1pp/2p5/4Pp2/8/2N2N1P/PPP2PP1/R1BR2K1 w - - 0 1"
+        )


### PR DESCRIPTION
This PR adds a function that allows the position to be updated by making moves from the current position. Since the resulting position will be similar, it's good to preserve the transposition table. So self._put("ucinewgame") is not called in this function.

Preserving the TT and not calling self._put("ucinewgame") is also added as an option to set_fen_position (e.g., the position that's being set could be similar to the current position, and the user may want to keep the TT). But the default behavior of set_fen_position is to still call self._put("ucinewgame"), if no argument is received saying what to do.