### PR TITLE
Prevent potential errors with the SF process, and misc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You should install the stockfish engine in your operating system globally or spe
 ```python
 from stockfish import Stockfish
 
-stockfish = Stockfish("/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
+stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 ```
 
 There are some default engine's settings:
@@ -48,7 +48,7 @@ There are some default engine's settings:
 
 You can change them during your Stockfish class initialization:
 ```python
-stockfish = Stockfish(parameters={"Threads": 2, "Minimum Thinking Time": 30})
+stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
 ### Set position by sequence of moves

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ There are some default engine's settings:
 }
 ```
 
-You can change them, as well as set the default depth, during your Stockfish class initialization:
+You can change them, as well as the default search depth, during your Stockfish class initialization:
 ```python
-stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=15, parameters={"Threads": 2, "Minimum Thinking Time": 30})
+stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=18, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
 ### Set position by sequence of moves

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ There are some default engine's settings:
 }
 ```
 
-You can change them during your Stockfish class initialization:
+You can change them, as well as set the default depth, during your Stockfish class initialization:
 ```python
-stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", parameters={"Threads": 2, "Minimum Thinking Time": 30})
+stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=15, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
 ### Set position by sequence of moves

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -16,7 +16,7 @@ class Stockfish:
     """Integrates the Stockfish chess engine with Python."""
 
     def __init__(
-        self, path: str = "stockfish", depth: int = 2, parameters: dict = None
+        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
     ) -> None:
         self.default_stockfish_params = {
             "Write Debug Log": "false",
@@ -35,13 +35,15 @@ class Stockfish:
             "UCI_Elo": 1350,
             "UCI_ShowWDL": "false",
         }
-        self.stockfish = subprocess.Popen(
+        self._stockfish = subprocess.Popen(
             path,
             universal_newlines=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+
+        self._has_quit_command_been_sent = False
 
         self._stockfish_major_version: int = int(
             self._read_line().split(" ")[1].split(".")[0]
@@ -93,15 +95,17 @@ class Stockfish:
         self.info = ""
 
     def _put(self, command: str) -> None:
-        if not self.stockfish.stdin:
+        if not self._stockfish.stdin:
             raise BrokenPipeError()
-        self.stockfish.stdin.write(f"{command}\n")
-        self.stockfish.stdin.flush()
+        if self._stockfish.poll() is None and not self._has_quit_command_been_sent:
+            self._stockfish.stdin.write(f"{command}\n")
+            self._stockfish.stdin.flush()
+            self._has_quit_command_been_sent = command == "quit"
 
     def _read_line(self) -> str:
-        if not self.stockfish.stdout:
+        if not self._stockfish.stdout:
             raise BrokenPipeError()
-        return self.stockfish.stdout.readline().strip()
+        return self._stockfish.stdout.readline().strip()
 
     def _set_option(self, name: str, value: Any) -> None:
         self._put(f"setoption name {name} value {value}")
@@ -543,5 +547,6 @@ class Stockfish:
         return self._stockfish_major_version
 
     def __del__(self) -> None:
-        self._put("quit")
-        self.stockfish.kill()
+        if self._stockfish.poll() is None:
+            self._put("quit")
+            self._stockfish.kill()

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -102,7 +102,6 @@ class Stockfish:
             self._stockfish.stdin.flush()
             if command == "quit":
                 self._has_quit_command_been_sent = True
-                # sleep(0.1)
 
     def _read_line(self) -> str:
         if not self._stockfish.stdout:
@@ -554,4 +553,3 @@ class Stockfish:
             self._stockfish.kill()
             while self._stockfish.poll() == None:
                 pass
-            # sleep(0.1)

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional
 import copy
 from os import path
 from dataclasses import dataclass
-from time import sleep
 
 
 class Stockfish:
@@ -103,7 +102,7 @@ class Stockfish:
             self._stockfish.stdin.flush()
             if command == "quit":
                 self._has_quit_command_been_sent = True
-                sleep(0.1)
+                # sleep(0.1)
 
     def _read_line(self) -> str:
         if not self._stockfish.stdout:
@@ -553,4 +552,6 @@ class Stockfish:
         if self._stockfish.poll() is None:
             self._put("quit")
             self._stockfish.kill()
-            sleep(0.1)
+            while self._stockfish.poll() == None:
+                pass
+            # sleep(0.1)

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -10,6 +10,7 @@ from typing import Any, List, Optional
 import copy
 from os import path
 from dataclasses import dataclass
+from time import sleep
 
 
 class Stockfish:
@@ -100,7 +101,9 @@ class Stockfish:
         if self._stockfish.poll() is None and not self._has_quit_command_been_sent:
             self._stockfish.stdin.write(f"{command}\n")
             self._stockfish.stdin.flush()
-            self._has_quit_command_been_sent = command == "quit"
+            if command == "quit":
+                self._has_quit_command_been_sent = True
+                sleep(0.1)
 
     def _read_line(self) -> str:
         if not self._stockfish.stdout:
@@ -550,3 +553,4 @@ class Stockfish:
         if self._stockfish.poll() is None:
             self._put("quit")
             self._stockfish.kill()
+            sleep(0.1)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -507,7 +507,7 @@ class TestStockfish:
         stockfish.__del__()
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
-        
+
     def test_multiple_quit_commands(self, stockfish):
         # Test multiple quit commands, and include a call to del too. All of
         # them should run without causing some Exception.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -512,3 +512,24 @@ class TestStockfish:
         sf.__del__()
         assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
+
+    def test_multiple_quit_calls(self):
+        sf = Stockfish()
+        assert sf._stockfish.poll() is None
+        assert not sf._has_quit_command_been_sent
+        sf._put("quit")
+        assert sf._stockfish.poll() is None
+        assert sf._has_quit_command_been_sent
+        time.sleep(2)
+        sf._put("quit")
+        assert sf._stockfish.poll() is None
+        assert sf._has_quit_command_been_sent
+        time.sleep(2)
+        sf.__del__()
+        time.sleep(2)
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent
+        sf._put("quit")
+        time.sleep(2)
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -518,6 +518,7 @@ class TestStockfish:
         assert sf._stockfish.poll() is None
         assert not sf._has_quit_command_been_sent
         sf._put("quit")
+        time.sleep(2)
         assert sf._stockfish.poll() is None
         assert sf._has_quit_command_been_sent
         time.sleep(2)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -166,6 +166,7 @@ class TestStockfish:
         assert stockfish.get_parameters()["Skill Level"] == 20
 
     def test_set_elo_rating(self, stockfish):
+        print(stockfish.depth)
         stockfish.set_fen_position(
             "rnbqkbnr/ppp2ppp/3pp3/8/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1"
         )
@@ -187,6 +188,7 @@ class TestStockfish:
         assert stockfish.get_parameters()["UCI_Elo"] == 2000
 
         stockfish.set_elo_rating(1350)
+        print(stockfish.depth)
         assert stockfish.get_best_move() in (
             "d1e2",
             "b1c3",
@@ -517,10 +519,8 @@ class TestStockfish:
         assert sf._stockfish.poll() is None
         assert not sf._has_quit_command_been_sent
         sf._put("quit")
-        assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
         sf._put("quit")
-        assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
         sf.__del__()
         assert sf._stockfish.poll() is not None

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 from timeit import default_timer
+import time
 
 from stockfish import Stockfish
 
@@ -496,3 +497,18 @@ class TestStockfish:
         result = stockfish.benchmark(params)
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
+
+    def test_multiple_calls_to_del(self):
+        # Don't use the same stockfish reference as in the other tests, since
+        # the del method will be called on it in this test.
+        sf = Stockfish()
+        assert sf._stockfish.poll() is None
+        assert not sf._has_quit_command_been_sent
+        sf.__del__()
+        time.sleep(2)
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent
+        time.sleep(2)
+        sf.__del__()
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -166,7 +166,7 @@ class TestStockfish:
         assert stockfish.get_parameters()["Skill Level"] == 20
 
     def test_set_elo_rating(self, stockfish):
-        print(stockfish.depth)
+        stockfish.set_depth(2)
         stockfish.set_fen_position(
             "rnbqkbnr/ppp2ppp/3pp3/8/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1"
         )
@@ -188,7 +188,6 @@ class TestStockfish:
         assert stockfish.get_parameters()["UCI_Elo"] == 2000
 
         stockfish.set_elo_rating(1350)
-        print(stockfish.depth)
         assert stockfish.get_best_move() in (
             "d1e2",
             "b1c3",
@@ -499,33 +498,29 @@ class TestStockfish:
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
-    def test_multiple_calls_to_del(self):
-        # Don't use the same stockfish reference as in the other tests, since
-        # the del method will be called on it in this test.
-        sf = Stockfish()
-        assert sf._stockfish.poll() is None
-        assert not sf._has_quit_command_been_sent
-        sf.__del__()
-        assert sf._stockfish.poll() is not None
-        assert sf._has_quit_command_been_sent
-        sf.__del__()
-        assert sf._stockfish.poll() is not None
-        assert sf._has_quit_command_been_sent
-
-    def test_multiple_quit_commands(self):
+    def test_multiple_calls_to_del(self, stockfish):
+        assert stockfish._stockfish.poll() is None
+        assert not stockfish._has_quit_command_been_sent
+        stockfish.__del__()
+        assert stockfish._stockfish.poll() is not None
+        assert stockfish._has_quit_command_been_sent
+        stockfish.__del__()
+        assert stockfish._stockfish.poll() is not None
+        assert stockfish._has_quit_command_been_sent
+        
+    def test_multiple_quit_commands(self, stockfish):
         # Test multiple quit commands, and include a call to del too. All of
         # them should run without causing some Exception.
-        sf = Stockfish()
-        assert sf._stockfish.poll() is None
-        assert not sf._has_quit_command_been_sent
-        sf._put("quit")
-        assert sf._has_quit_command_been_sent
-        sf._put("quit")
-        assert sf._has_quit_command_been_sent
-        sf.__del__()
-        assert sf._stockfish.poll() is not None
-        assert sf._has_quit_command_been_sent
-        sf._put(f"go depth {10}")
+        assert stockfish._stockfish.poll() is None
+        assert not stockfish._has_quit_command_been_sent
+        stockfish._put("quit")
+        assert stockfish._has_quit_command_been_sent
+        stockfish._put("quit")
+        assert stockfish._has_quit_command_been_sent
+        stockfish.__del__()
+        assert stockfish._stockfish.poll() is not None
+        assert stockfish._has_quit_command_been_sent
+        stockfish._put(f"go depth {10}")
         # Should do nothing, and change neither of the values below.
-        assert sf._stockfish.poll() is not None
-        assert sf._has_quit_command_been_sent
+        assert stockfish._stockfish.poll() is not None
+        assert stockfish._has_quit_command_been_sent

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,6 +1,5 @@
 import pytest
 from timeit import default_timer
-import time
 
 from stockfish import Stockfish
 
@@ -505,32 +504,28 @@ class TestStockfish:
         assert sf._stockfish.poll() is None
         assert not sf._has_quit_command_been_sent
         sf.__del__()
-        time.sleep(2)
         assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
-        time.sleep(2)
         sf.__del__()
         assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
 
-    def test_multiple_quit_calls(self):
+    def test_multiple_quit_commands(self):
+        # Test multiple quit commands, and include a call to del too. All of
+        # them should run without causing some Exception.
         sf = Stockfish()
         assert sf._stockfish.poll() is None
         assert not sf._has_quit_command_been_sent
         sf._put("quit")
-        time.sleep(2)
-        assert sf._stockfish.poll() is None
-        assert sf._has_quit_command_been_sent
-        time.sleep(2)
-        sf._put("quit")
-        assert sf._stockfish.poll() is None
-        assert sf._has_quit_command_been_sent
-        time.sleep(2)
-        sf.__del__()
-        time.sleep(2)
         assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent
         sf._put("quit")
-        time.sleep(2)
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent
+        sf.__del__()
+        assert sf._stockfish.poll() is not None
+        assert sf._has_quit_command_been_sent
+        sf._put(f"go depth {10}")
+        # Should do nothing, and change neither of the values below.
         assert sf._stockfish.poll() is not None
         assert sf._has_quit_command_been_sent


### PR DESCRIPTION
This PR has a number of small things:

- If the user calls the \_\_del\_\_ method themselves, this could potentially result in an error, since the OS may call \_\_del\_\_ later. So in each call to \_\_del\_\_, ensure that self._stockfish is still running (i.e., = None).
- A check is also implemented in the _put function, such that if self._stockfish isn't running, or if the "quit" command has already been sent to Stockfish, then the stdin.write() and stdin.flush() lines won't be executed.
- Renamed the self.stockfish instance variable to self._stockfish, in order to indicate that it should be treated as private.
- Changed the default search depth from 2 to 15, in case the user doesn't set it themselves. 15 is a good depth value since it's nearly instantaneous while still being fairly strong.
- Added to the example in the readme for creating a Stockfish instance, in order to show how to send all the optional arguments together.