### PR TITLE
Modify tests for various SF versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ stockfish.get_stockfish_major_version()
 11
 ```
 
-### Find if the version of Stockfish being used is a developemnt build
+### Find if the version of Stockfish being used is a development build
 ```python
 stockfish.is_development_build_of_engine()
 ```

--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ stockfish.get_stockfish_major_version()
 11
 ```
 
+### Get whether the major version represents a dd/mm/yy date
+```python
+stockfish.is_stockfish_major_version_a_date()
+```
+```text
+False
+```
+
 ## Testing
 ```bash
 $ python setup.py test

--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ stockfish.get_stockfish_major_version()
 11
 ```
 
-### Get whether the major version represents a dd/mm/yy date
+### Find if the version of Stockfish being used is a developemnt build
 ```python
-stockfish.is_stockfish_major_version_a_date()
+stockfish.is_development_build_of_engine()
 ```
 ```text
 False

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -551,5 +551,5 @@ class Stockfish:
         if self._stockfish.poll() is None:
             self._put("quit")
             self._stockfish.kill()
-            while self._stockfish.poll() == None:
+            while self._stockfish.poll() is None:
                 pass

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -557,7 +557,7 @@ class Stockfish:
         """
         return (
             self._stockfish_major_version >= 10109
-            and self._stockfish_major_version <= 311229
+            and self._stockfish_major_version <= 311299
         )
 
     def __del__(self) -> None:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -547,6 +547,19 @@ class Stockfish:
 
         return self._stockfish_major_version
 
+    def is_stockfish_major_version_a_date(self) -> bool:
+        """Returns whether the major version is a date.
+
+        Returns:
+            True if the major version is a date, indicating SF was downloaded
+            as a development build. E.g., 020122 is the major version
+            of the SF development build released on Jan 2, 2022.
+        """
+        return (
+            self._stockfish_major_version >= 10109
+            and self._stockfish_major_version <= 311229
+        )
+
     def __del__(self) -> None:
         if self._stockfish.poll() is None:
             self._put("quit")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -547,13 +547,15 @@ class Stockfish:
 
         return self._stockfish_major_version
 
-    def is_stockfish_major_version_a_date(self) -> bool:
-        """Returns whether the major version is a date.
+    def is_development_build_of_engine(self) -> bool:
+        """Returns whether the version of Stockfish being used is a
+           development build.
 
         Returns:
-            True if the major version is a date, indicating SF was downloaded
-            as a development build. E.g., 020122 is the major version
-            of the SF development build released on Jan 2, 2022.
+            True if the major version is a date, indicating SF is a
+            development build. E.g., 020122 is the major version of the SF
+            development build released on Jan 2, 2022. Otherwise, False is
+            returned (which means the engine is an official release of SF).
         """
         return (
             self._stockfish_major_version >= 10109

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -177,17 +177,14 @@ class TestStockfish:
 
         stockfish.set_elo_rating(2000)
         assert stockfish.get_best_move() in (
-            "b2b3",
-            "b2b3",
-            "d2d3",
             "d2d4",
             "b1c3",
             "d1e2",
-            "g2g3",
             "c2c4",
             "f1e2",
             "h2h3",
             "c2c3",
+            "f1d3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 2000
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -146,6 +146,7 @@ class TestStockfish:
 
         stockfish.set_skill_level(1)
         assert stockfish.get_best_move() in (
+            "b2b3",
             "d2d3",
             "d2d4",
             "b1c3",
@@ -155,7 +156,6 @@ class TestStockfish:
             "f1e2",
             "c2c3",
             "h2h3",
-            "b2b3",
         )
         assert stockfish.get_parameters()["Skill Level"] == 1
 
@@ -203,10 +203,7 @@ class TestStockfish:
         major_version = stockfish.get_stockfish_major_version()
 
         expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1b5", "f1e2"]
-        if major_version >= 12 and not (
-            major_version >= 10109 and major_version <= 123129
-        ):
-            # SF major version is at least 12, and not a dd/mm/yy date.
+        if major_version >= 12 and not (stockfish.is_stockfish_major_version_a_date()):
             expected_best_moves.remove("f1e2")
 
         assert stockfish.get_best_move() in expected_best_moves
@@ -295,10 +292,9 @@ class TestStockfish:
         )
 
     def test_get_stockfish_major_version(self, stockfish):
-        major_version = stockfish.get_stockfish_major_version()
-        if not (major_version >= 10109 and major_version <= 123129):
-            # Not a dd/mm/yy date.
-            assert stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
+        assert (
+            stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
+        ) != stockfish.is_stockfish_major_version_a_date()
 
     def test_get_evaluation_cp(self, stockfish):
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -155,6 +155,8 @@ class TestStockfish:
             "g2g3",
             "c2c4",
             "f1e2",
+            "c2c3",
+            "h2h3",
         )
         assert stockfish.get_parameters()["Skill Level"] == 1
 
@@ -162,11 +164,11 @@ class TestStockfish:
         assert stockfish.get_best_move() in (
             "d2d4",
             "b1c3",
+            "c2c4",
         )
         assert stockfish.get_parameters()["Skill Level"] == 20
 
     def test_set_elo_rating(self, stockfish):
-        stockfish.set_depth(2)
         stockfish.set_fen_position(
             "rnbqkbnr/ppp2ppp/3pp3/8/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1"
         )
@@ -184,6 +186,8 @@ class TestStockfish:
             "g2g3",
             "c2c4",
             "f1e2",
+            "h2h3",
+            "c2c3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 2000
 
@@ -195,8 +199,18 @@ class TestStockfish:
             "d2d4",
             "c2c4",
             "f1e2",
+            "h2h3",
+            "c2c3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 1350
+        
+        stockfish.set_elo_rating(2850)
+        assert stockfish.get_best_move() in (
+            "d2d4",
+            "b1c3",
+            "c2c4",
+        )
+        assert stockfish.get_parameters()["UCI_Elo"] == 2850
 
     def test_stockfish_constructor_with_custom_params(self, stockfish):
         stockfish.set_skill_level(1)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -195,9 +195,19 @@ class TestStockfish:
             "g2g3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 1350
-        
+
         stockfish.set_elo_rating(2850)
-        assert stockfish.get_best_move() == "d2d4"
+
+        expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1e2"]
+        if (
+            stockfish.get_stockfish_major_version() >= 12
+            and stockfish.get_stockfish_major_version() < 100
+        ):
+            # SF is an officially released version at least as recent as 12.
+            expected_best_moves.remove("f1e2")
+
+        assert stockfish.get_best_move() in expected_best_moves
+
         assert stockfish.get_parameters()["UCI_Elo"] == 2850
 
     def test_stockfish_constructor_with_custom_params(self, stockfish):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -193,15 +193,17 @@ class TestStockfish:
             "c2c3",
             "f1b5",
             "g2g3",
+            "h2h3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 1350
 
         stockfish.set_elo_rating(2850)
         major_version = stockfish.get_stockfish_major_version()
 
-        expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1e2"]
-        if (major_version >= 12 and 
-           not (major_version >= 10109 and major_version <= 123129)):
+        expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1b5", "f1e2"]
+        if major_version >= 12 and not (
+            major_version >= 10109 and major_version <= 123129
+        ):
             # SF major version is at least 12, and not a dd/mm/yy date.
             expected_best_moves.remove("f1e2")
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -203,7 +203,7 @@ class TestStockfish:
         major_version = stockfish.get_stockfish_major_version()
 
         expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1b5", "f1e2"]
-        if major_version >= 12 and not (stockfish.is_stockfish_major_version_a_date()):
+        if major_version >= 12 and not stockfish.is_development_build_of_engine():
             expected_best_moves.remove("f1e2")
 
         assert stockfish.get_best_move() in expected_best_moves
@@ -294,7 +294,7 @@ class TestStockfish:
     def test_get_stockfish_major_version(self, stockfish):
         assert (
             stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
-        ) != stockfish.is_stockfish_major_version_a_date()
+        ) != stockfish.is_development_build_of_engine()
 
     def test_get_evaluation_cp(self, stockfish):
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -155,6 +155,7 @@ class TestStockfish:
             "f1e2",
             "c2c3",
             "h2h3",
+            "b2b3",
         )
         assert stockfish.get_parameters()["Skill Level"] == 1
 
@@ -179,6 +180,7 @@ class TestStockfish:
             "h2h3",
             "c2c3",
             "f1d3",
+            "a2a3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 2000
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -200,7 +200,7 @@ class TestStockfish:
 
     def test_stockfish_constructor_with_custom_params(self, stockfish):
         stockfish.set_skill_level(1)
-        assert stockfish.get_parameters() == {
+        expected_params = {
             "Write Debug Log": "false",
             "Contempt": 0,
             "Min Split Depth": 0,
@@ -216,6 +216,9 @@ class TestStockfish:
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
         }
+        if stockfish.does_current_engine_version_have_wdl_option():
+            expected_params["UCI_ShowWDL"] = "false"
+        assert stockfish.get_parameters() == expected_params
 
     def test_get_board_visual(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])
@@ -445,12 +448,12 @@ class TestStockfish:
         if stockfish.does_current_engine_version_have_wdl_option():
             stockfish.set_show_wdl_option(True)
             assert stockfish._parameters["UCI_ShowWDL"] == "true"
-            assert len(Stockfish.get_wdl_stats()) == 3
+            assert len(stockfish.get_wdl_stats()) == 3
             assert stockfish._parameters["UCI_ShowWDL"] == "true"
             stockfish.set_show_wdl_option(False)
             assert stockfish._parameters["UCI_ShowWDL"] == "false"
             stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
-            assert Stockfish.get_wdl_stats() is None
+            assert stockfish.get_wdl_stats() is None
             assert stockfish._parameters["UCI_ShowWDL"] == "false"
         else:
             with pytest.raises(RuntimeError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -146,8 +146,6 @@ class TestStockfish:
 
         stockfish.set_skill_level(1)
         assert stockfish.get_best_move() in (
-            "b2b3",
-            "b2b3",
             "d2d3",
             "d2d4",
             "b1c3",
@@ -161,11 +159,7 @@ class TestStockfish:
         assert stockfish.get_parameters()["Skill Level"] == 1
 
         stockfish.set_skill_level(20)
-        assert stockfish.get_best_move() in (
-            "d2d4",
-            "b1c3",
-            "c2c4",
-        )
+        assert stockfish.get_best_move() == "d2d4"
         assert stockfish.get_parameters()["Skill Level"] == 20
 
     def test_set_elo_rating(self, stockfish):
@@ -196,17 +190,14 @@ class TestStockfish:
             "d2d4",
             "c2c4",
             "f1e2",
-            "h2h3",
             "c2c3",
+            "f1b5",
+            "g2g3",
         )
         assert stockfish.get_parameters()["UCI_Elo"] == 1350
         
         stockfish.set_elo_rating(2850)
-        assert stockfish.get_best_move() in (
-            "d2d4",
-            "b1c3",
-            "c2c4",
-        )
+        assert stockfish.get_best_move() == "d2d4"
         assert stockfish.get_parameters()["UCI_Elo"] == 2850
 
     def test_stockfish_constructor_with_custom_params(self, stockfish):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -197,13 +197,12 @@ class TestStockfish:
         assert stockfish.get_parameters()["UCI_Elo"] == 1350
 
         stockfish.set_elo_rating(2850)
+        major_version = stockfish.get_stockfish_major_version()
 
         expected_best_moves = ["d2d4", "b1c3", "c2c3", "c2c4", "f1e2"]
-        if (
-            stockfish.get_stockfish_major_version() >= 12
-            and stockfish.get_stockfish_major_version() < 100
-        ):
-            # SF is an officially released version at least as recent as 12.
+        if (major_version >= 12 and 
+           not (major_version >= 10109 and major_version <= 123129)):
+            # SF major version is at least 12, and not a dd/mm/yy date.
             expected_best_moves.remove("f1e2")
 
         assert stockfish.get_best_move() in expected_best_moves
@@ -292,7 +291,10 @@ class TestStockfish:
         )
 
     def test_get_stockfish_major_version(self, stockfish):
-        assert stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
+        major_version = stockfish.get_stockfish_major_version()
+        if not (major_version >= 10109 and major_version <= 123129):
+            # Not a dd/mm/yy date.
+            assert stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
 
     def test_get_evaluation_cp(self, stockfish):
         stockfish.set_fen_position(
@@ -438,7 +440,7 @@ class TestStockfish:
             )
             stockfish.set_show_wdl_option(False)
             wdl_stats = stockfish.get_wdl_stats()
-            assert wdl_stats[1] > wdl_stats[0] * 4
+            assert wdl_stats[1] > wdl_stats[0] * 3.5
             assert wdl_stats[0] > wdl_stats[2] * 1.8
             assert stockfish._parameters["UCI_ShowWDL"] == "false"
             stockfish.set_fen_position("8/8/8/8/8/6k1/6p1/6K1 w - - 0 1")

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -304,6 +304,7 @@ class TestStockfish:
         assert "depth 12" in stockfish.info
 
     def test_get_best_move_wrong_position(self, stockfish):
+        stockfish.set_depth(2)
         wrong_fen = "3kk3/8/8/8/8/8/8/3KK3 w - - 0 0"
         stockfish.set_fen_position(wrong_fen)
         assert stockfish.get_best_move() in (


### PR DESCRIPTION
Sorry for all the recent PRs, this should be the last one for now :)

- There were some bugs in my recent tests, so they're fixed here. 
- Various tests have also been updated, since some versions of SF caused problems when running them.
- A test for UCI_Elo = 2850 has been added.
- A depth of 2 is now only used in a test function for testing an illegal position. In some other test functions where depth 2 was used before, I've removed moves that will no longer appear with depth 15.
- A new function is added to models.py, that determines if the stockfish major version represents a dd/mm/yy date (which is the case if SF is a development build instead of a main release).