### PR TITLE
Add btime and wtime options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ stockfish.get_best_move()
 ```text
 d2d4
 ```
+It's possible to specify remaining time on black and/or white clock. Time is in milliseconds.
+```python
+stockfish.get_best_move(wtime=1000, btime=1000)
+```
 
 ### Get best move based on a time constraint
 ```python

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -255,7 +255,7 @@ class Stockfish:
 
     def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:
         """Returns best move with current position on the board.
-        Uses depth limit if both white and black remaining times are not specified.
+        wtime and btime arguments influence the search only if provided.
 
         Returns:
             A string of move in algebraic notation or None, if it's a mate now.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -125,7 +125,7 @@ class Stockfish:
     def _go_time(self, time: int) -> None:
         self._put(f"go movetime {time}")
 
-    def _go_remaining_time(self, wtime: int, btime: int) -> None:
+    def _go_remaining_time(self, wtime: Optional[int], btime: Optional[int]) -> None:
         cmd = "go"
         if wtime is not None:
             cmd += f" wtime {wtime}"

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -125,6 +125,14 @@ class Stockfish:
     def _go_time(self, time: int) -> None:
         self._put(f"go movetime {time}")
 
+    def _go_remaining_time(self, wtime: int, btime: int) -> None:
+        cmd = "go"
+        if wtime is not None:
+            cmd += f" wtime {wtime}"
+        if btime is not None:
+            cmd += f" btime {btime}"
+        self._put(cmd)
+
     @staticmethod
     def _convert_move_list_to_str(moves: List[str]) -> str:
         result = ""
@@ -245,13 +253,17 @@ class Stockfish:
         self._prepare_for_new_position(send_ucinewgame_token)
         self._put(f"position fen {fen_position}")
 
-    def get_best_move(self) -> Optional[str]:
+    def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:
         """Returns best move with current position on the board.
+        Uses depth limit if both white and black remaining times are not specified.
 
         Returns:
             A string of move in algebraic notation or None, if it's a mate now.
         """
-        self._go()
+        if wtime is not None or btime is not None:
+            self._go_remaining_time(wtime, btime)
+        else:
+            self._go()
         last_text: str = ""
         while True:
             text = self._read_line()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -30,7 +30,7 @@ class TestStockfish:
         assert best_move in ("d2d4")
         best_move = stockfish.get_best_move(wtime=1000, btime=1000)
         assert best_move in ("e2e4", "d2d4")
-        best_move = stockfish.get_best_move(wtime=5*60*1000, btime=1000)
+        best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
     def test_set_position_resets_info(self, stockfish):
@@ -58,7 +58,7 @@ class TestStockfish:
         assert best_move in ("d2d4")
         best_move = stockfish.get_best_move(wtime=1000, btime=1000)
         assert best_move in ("d2d4", "b1c3")
-        best_move = stockfish.get_best_move(wtime=5*60*1000, btime=1000)
+        best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
     def test_get_best_move_checkmate(self, stockfish):
@@ -74,7 +74,7 @@ class TestStockfish:
         assert stockfish.get_best_move(wtime=1000) is None
         assert stockfish.get_best_move(btime=1000) is None
         assert stockfish.get_best_move(wtime=1000, btime=1000) is None
-        assert stockfish.get_best_move(wtime=5*60*1000, btime=1000) is None
+        assert stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000) is None
 
     def test_set_fen_position(self, stockfish):
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -25,11 +25,11 @@ class TestStockfish:
 
     def test_get_best_move_remaining_time_first_move(self, stockfish):
         best_move = stockfish.get_best_move(wtime=1000)
-        assert best_move in ("a2a3")
+        assert best_move in ("a2a3", "d2d4", "e2e4", "g1f3")
         best_move = stockfish.get_best_move(btime=1000)
-        assert best_move in ("d2d4")
+        assert best_move in ("d2d4", "e2e4")
         best_move = stockfish.get_best_move(wtime=1000, btime=1000)
-        assert best_move in ("e2e4", "d2d4")
+        assert best_move in ("e2e4", "d2d4", "c2c4", "e2e3")
         best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
@@ -53,11 +53,11 @@ class TestStockfish:
     def test_get_best_move_remaining_time_not_first_move(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move(wtime=1000)
-        assert best_move in ("a2a3")
+        assert best_move in ("a2a3", "d1e2", "b1c3")
         best_move = stockfish.get_best_move(btime=1000)
-        assert best_move in ("d2d4")
-        best_move = stockfish.get_best_move(wtime=1000, btime=1000)
         assert best_move in ("d2d4", "b1c3")
+        best_move = stockfish.get_best_move(wtime=1000, btime=1000)
+        assert best_move in ("d2d4", "b1c3", "g1f3")
         best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -23,6 +23,16 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
+    def test_get_best_move_remaining_time_first_move(self, stockfish):
+        best_move = stockfish.get_best_move(wtime=1000)
+        assert best_move in ("a2a3")
+        best_move = stockfish.get_best_move(btime=1000)
+        assert best_move in ("d2d4")
+        best_move = stockfish.get_best_move(wtime=1000, btime=1000)
+        assert best_move in ("e2e4", "d2d4")
+        best_move = stockfish.get_best_move(wtime=5*60*1000, btime=1000)
+        assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
+
     def test_set_position_resets_info(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         stockfish.get_best_move()
@@ -40,6 +50,17 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("d2d4", "g1f3")
 
+    def test_get_best_move_remaining_time_not_first_move(self, stockfish):
+        stockfish.set_position(["e2e4", "e7e6"])
+        best_move = stockfish.get_best_move(wtime=1000)
+        assert best_move in ("a2a3")
+        best_move = stockfish.get_best_move(btime=1000)
+        assert best_move in ("d2d4")
+        best_move = stockfish.get_best_move(wtime=1000, btime=1000)
+        assert best_move in ("d2d4", "b1c3")
+        best_move = stockfish.get_best_move(wtime=5*60*1000, btime=1000)
+        assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
+
     def test_get_best_move_checkmate(self, stockfish):
         stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
         assert stockfish.get_best_move() is None
@@ -47,6 +68,13 @@ class TestStockfish:
     def test_get_best_move_time_checkmate(self, stockfish):
         stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
         assert stockfish.get_best_move_time(1000) is None
+
+    def test_get_best_move_remaining_time_checkmate(self, stockfish):
+        stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
+        assert stockfish.get_best_move(wtime=1000) is None
+        assert stockfish.get_best_move(btime=1000) is None
+        assert stockfish.get_best_move(wtime=1000, btime=1000) is None
+        assert stockfish.get_best_move(wtime=5*60*1000, btime=1000) is None
 
     def test_set_fen_position(self, stockfish):
         stockfish.set_fen_position(


### PR DESCRIPTION
As issued [here](https://github.com/zhelyabuzhsky/stockfish/issues/38), btime and wtime commands are useful in order to let the engine decide the time spent in searching for the best move.

As reported in the UCI description:
```
If one command is not sent its value should be interpreted as it would not influence the search.
```
So i thought that the use of optional arguments in the already existing get_best_move function would prevent from having lots of different methods for move searching.