### PR TITLE
Detect whether a move will be a capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,14 @@ stockfish.get_what_is_on_square("e1")
 ```
 
 ### Find if a move will be a capture (and if so, what type of capture)
-The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square). The function will return one of the following strings: "direct capture", "en passant", or "no capture".  
+The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square).   
+The function will return one of the following enum members from a custom Stockfish.Capture enum: DIRECT_CAPTURE, EN_PASSANT, or NO_CAPTURE.  
 For example, say the current position is the one after 1.e4 Nf6 2.Nc3 e6 3.e5 d5.
 ```python
-stockfish.will_move_be_a_capture("c3d5")  # returns "direct capture"  
-stockfish.will_move_be_a_capture("e5f6")  # returns "direct capture"  
-stockfish.will_move_be_a_capture("e5d6")  # returns "en passant"  
-stockfish.will_move_be_a_capture("f1e2")  # returns "no capture"  
+stockfish.will_move_be_a_capture("c3d5")  # returns Stockfish.Capture.DIRECT_CAPTURE  
+stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAPTURE  
+stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT  
+stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 There are some default engine's settings:
 ```python
 {
-    "Write Debug Log": "false",
+    "Debug Log File": "",
     "Contempt": 0,
     "Min Split Depth": 0,
     "Threads": 1,
@@ -39,9 +39,9 @@ There are some default engine's settings:
     "Hash": 16,
     "MultiPV": 1,
     "Skill Level": 20,
-    "Move Overhead": 30,
+    "Move Overhead": 10,
     "Minimum Thinking Time": 20,
-    "Slow Mover": 80,
+    "Slow Mover": 100,
     "UCI_Chess960": "false",
     "UCI_LimitStrength": "false",
     "UCI_Elo": 1350
@@ -154,7 +154,7 @@ stockfish.get_parameters()
 ```
 ```text
 {
-    "Write Debug Log": "false",
+    "Debug Log File": "",
     "Contempt": 0,
     "Min Split Depth": 0,
     "Threads": 1,
@@ -162,9 +162,9 @@ stockfish.get_parameters()
     "Hash": 16,
     "MultiPV": 1,
     "Skill Level": 20,
-    "Move Overhead": 30,
+    "Move Overhead": 10,
     "Minimum Thinking Time": 20,
-    "Slow Mover": 80,
+    "Slow Mover": 100,
     "UCI_Chess960": "false",
     "UCI_LimitStrength": "false",
     "UCI_Elo": 1350

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Time constraint is in milliseconds
 e2e4
 ```
 
-
 ### Check is move correct with current position
 ```python
 stockfish.is_move_correct('a2a3')
@@ -160,6 +159,18 @@ stockfish.get_parameters()
     'Slow Mover': 80,
     'UCI_Chess960': 'false'
 }
+```
+
+### Reset the engine's parameters to the default
+```python
+stockfish.reset_parameters()
+```
+
+### Update the engine's parameters
+This function takes a dictionary of one or more (key, value) pairs as its argument. Then, for the engine's parameters, it updates each  
+specified key with the corresponding value. For example:
+```python
+stockfish.update_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
 ```
 
 ### Get current board position in Forsyth–Edwards notation (FEN)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ There are some default engine's settings:
     "Minimum Thinking Time": 20,
     "Slow Mover": 80,
     "UCI_Chess960": "false",
+    "UCI_LimitStrength": "false",
+    "UCI_Elo": 1350
 }
 ```
 
@@ -51,7 +53,12 @@ You can change them, as well as the default search depth, during your Stockfish 
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=18, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
-### Set position by sequence of moves
+These parameters can also be updated at any time by calling the "update_engine_parameters" function:
+```python
+stockfish.update_engine_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
+```
+
+### Set position by a sequence of moves from the starting position
 ```python
 stockfish.set_position(["e2e4", "e7e6"])
 ```
@@ -62,6 +69,7 @@ stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 ```
 
 ### Set position by Forsyth–Edwards Notation (FEN)
+Note that if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
 ```
@@ -146,31 +154,26 @@ stockfish.get_parameters()
 ```
 ```text
 {
-    'Write Debug Log': 'false',
-    'Contempt': 0,
-    'Min Split Depth': 0,
-    'Threads': 1,
-    'Ponder': 'false',
-    'Hash': 16,
-    'MultiPV': 1,
-    'Skill Level': 20,
-    'Move Overhead': 30,
-    'Minimum Thinking Time': 20,
-    'Slow Mover': 80,
-    'UCI_Chess960': 'false'
+    "Write Debug Log": "false",
+    "Contempt": 0,
+    "Min Split Depth": 0,
+    "Threads": 1,
+    "Ponder": "false",
+    "Hash": 16,
+    "MultiPV": 1,
+    "Skill Level": 20,
+    "Move Overhead": 30,
+    "Minimum Thinking Time": 20,
+    "Slow Mover": 80,
+    "UCI_Chess960": "false",
+    "UCI_LimitStrength": "false",
+    "UCI_Elo": 1350
 }
 ```
 
 ### Reset the engine's parameters to the default
 ```python
-stockfish.reset_parameters()
-```
-
-### Update the engine's parameters
-This function takes a dictionary of one or more (key, value) pairs as its argument. Then, for the engine's parameters, it updates each  
-specified key with the corresponding value. For example:
-```python
-stockfish.update_engine_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
+stockfish.reset_engine_parameters()
 ```
 
 ### Get current board position in Forsyth–Edwards notation (FEN)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ from stockfish import Stockfish
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 ```
 
-There are some default engine's settings:
+There are some default engine settings:
 ```python
 {
     "Debug Log File": "",
@@ -36,7 +36,7 @@ There are some default engine's settings:
     "Min Split Depth": 0,
     "Threads": 1,
     "Ponder": "false",
-    "Hash": 16,
+    "Hash": 1024,
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,
@@ -55,7 +55,7 @@ stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64",
 
 These parameters can also be updated at any time by calling the "update_engine_parameters" function:
 ```python
-stockfish.update_engine_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
+stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
 ### Set position by a sequence of moves from the starting position
@@ -159,7 +159,7 @@ stockfish.get_parameters()
     "Min Split Depth": 0,
     "Threads": 1,
     "Ponder": "false",
-    "Hash": 16,
+    "Hash": 1024,
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ stockfish.reset_parameters()
 This function takes a dictionary of one or more (key, value) pairs as its argument. Then, for the engine's parameters, it updates each  
 specified key with the corresponding value. For example:
 ```python
-stockfish.update_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
+stockfish.update_engine_parameters({"MultiPV": 2, "UCI_Chess960": "true"}) # Gets SF to use 2 principal variations, and also to play Chess960.
 ```
 
 ### Get current board position in Forsyth–Edwards notation (FEN)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ stockfish.get_top_moves(3)
 ]
 ```
 
-### Get Stockfish's win/draw/loss stats for the side to move in the current position
+### Get Stockfish's win/draw/loss stats for the side to move in the current position  
+Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  
+use the "does_current_engine_version_have_wdl_option()" function below.
 ```python
 stockfish.get_wdl_stats()
 ```
@@ -122,11 +124,6 @@ stockfish.does_current_engine_version_have_wdl_option()
 ```
 ```text
 True
-```
-
-### Tell Stockfish whether or not to display WDL stats after analyzing a position
-```python
-stockfish.set_show_wdl_option(True)
 ```
 
 ### Set current engine's skill level (ignoring ELO rating)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,26 @@ stockfish.is_development_build_of_engine()
 False
 ```
 
+### Find what is on a certain square
+Will return one of: "P", "p", "N", "n", "B", "b", "R", "r", "Q", "q", "K", "k", or " ".  
+Uppercase is a white piece, lowercase is a black piece, and a single space means the square is empty.
+```python
+stockfish.get_what_is_on_square("e1")
+```
+```text
+"K"
+```
+
+### Find if a move will be a capture (and if so, what type of capture)
+The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square). The function will return one of the following strings: "direct capture", "en passant", or "no capture".  
+For example, say the current position is the one after 1.e4 Nf6 2.Nc3 e6 3.e5 d5.
+```python
+stockfish.will_move_be_a_capture("c3d5")  # returns "direct capture"  
+stockfish.will_move_be_a_capture("e5f6")  # returns "direct capture"  
+stockfish.will_move_be_a_capture("e5d6")  # returns "en passant"  
+stockfish.will_move_be_a_capture("f1e2")  # returns "no capture"  
+```
+
 ## Testing
 ```bash
 $ python setup.py test

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -10,6 +10,7 @@ from typing import Any, List, Optional
 import copy
 from os import path
 from dataclasses import dataclass
+from enum import Enum
 
 
 class Stockfish:
@@ -579,7 +580,12 @@ class Stockfish:
         rank_visual = self.get_board_visual().splitlines()[17 - 2 * rank_num]
         return rank_visual[2 + (ord(file_letter) - ord("a")) * 4]
 
-    def will_move_be_a_capture(self, move_value: str) -> str:
+    class Capture(Enum):
+        DIRECT_CAPTURE = "direct capture"
+        EN_PASSANT = "en passant"
+        NO_CAPTURE = "no capture"
+
+    def will_move_be_a_capture(self, move_value: str) -> Capture:
         """Returns whether the proposed move will be a direct capture,
            en passant, or not a capture at all.
 
@@ -588,21 +594,21 @@ class Stockfish:
                 The proposed move, in the notation that Stockfish uses.
                 E.g., "e2e4", "g1f3", etc.
 
-        Returns:
-            "direct capture" if the move will be a direct capture.
-            "en passant" if the move is a capture done with en passant.
-            "no capture" if the move does not capture anything.
+        Returns one of the following members of the Capture enum:
+            DIRECT_CAPTURE if the move will be a direct capture.
+            EN_PASSANT if the move is a capture done with en passant.
+            NO_CAPTURE if the move does not capture anything.
         """
         if not self.is_move_correct(move_value):
             raise ValueError("The proposed move is not valid in the current position.")
         if self.get_what_is_on_square(move_value[-2:]) != " ":
-            return "direct capture"
+            return Stockfish.Capture.DIRECT_CAPTURE
         elif move_value[-2:] == self.get_fen_position().split()[
             3
         ] and self.get_what_is_on_square(move_value[:2]) in ["P", "p"]:
-            return "en passant"
+            return Stockfish.Capture.EN_PASSANT
         else:
-            return "no capture"
+            return Stockfish.Capture.NO_CAPTURE
 
     def get_stockfish_major_version(self):
         """Returns Stockfish engine major version.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -550,11 +550,11 @@ class Stockfish:
         """
         self.depth = str(depth_value)
         
-    def will_move_be_a_capture(self, move: str) -> bool:
+    def will_move_be_a_capture(self, move_value: str) -> bool:
         """Returns whether the proposed move will be a capture.
         
         Args:
-            move:
+            move_value:
                 The proposed move, in the notation that Stockfish uses.
                 I.e., the coordinate of the starting square followed by
                 the coordinate of the destination square. 
@@ -565,20 +565,10 @@ class Stockfish:
             pieces or pawns.
             False if the destination square is empty.
         """
-
-        if len(move) != 4:
-            raise ValueError("The length of the string argument must be 4.")
-        is_white_to_move = "w" in self.get_fen_position()
-        side_to_move = "white" if is_white_to_move else "black"
-        pieces_of_side_to_move = (["P", "N", "B", "R", "Q", "K"] if is_white_to_move 
-                                  else ["p", "n", "b", "r", "q", "k"])
-        starting_square_piece = self.get_what_is_on_square(move[:2])
-        ending_square_piece = self.get_what_is_on_square(move[-2:])
-        if starting_square_piece not in pieces_of_side_to_move:
-            raise ValueError(f"There is no {side_to_move} piece on your move's starting square {move[:2]}")
-        if ending_square_piece in pieces_of_side_to_move:
-            raise ValueError(f"There is already a {side_to_move} piece on your move's ending square {move[-2:]}")
-        return ending_square_piece != " "
+        
+        if not self.is_move_correct(move_value):
+            raise ValueError("The proposed move is not valid in the current position.")
+        return self.get_what_is_on_square(move_value[-2:]) != " "
     
     def get_what_is_on_square(self, square: str) -> str:
         """Returns what is on the specified square.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -313,10 +313,7 @@ class Stockfish:
             text = self._read_line()
             splitted_text = text.split(" ")
             if splitted_text[0] == "bestmove":
-                if splitted_text[1] == "(none)":
-                    return False
-                else:
-                    return True
+                return splitted_text[1] != "(none)"
 
     def get_wdl_stats(self) -> Optional[List]:
         """Returns Stockfish's win/draw/loss stats for the side to move.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -565,8 +565,20 @@ class Stockfish:
             pieces or pawns.
             False if the destination square is empty.
         """
-        
-        # TODO - Call the other function you've written below.
+
+        if len(move) != 4:
+            raise ValueError("The length of the string argument must be 4.")
+        is_white_to_move = "w" in self.get_fen_position()
+        side_to_move = "white" if is_white_to_move else "black"
+        pieces_of_side_to_move = (["P", "N", "B", "R", "Q", "K"] if is_white_to_move 
+                                  else ["p", "n", "b", "r", "q", "k"])
+        starting_square_piece = self.get_what_is_on_square(move[:2])
+        ending_square_piece = self.get_what_is_on_square(move[-2:])
+        if starting_square_piece not in pieces_of_side_to_move:
+            raise ValueError(f"There is no {side_to_move} piece on your move's starting square {move[:2]}")
+        if ending_square_piece in pieces_of_side_to_move:
+            raise ValueError(f"There is already a {side_to_move} piece on your move's ending square {move[-2:]}")
+        return ending_square_piece != " "
     
     def get_what_is_on_square(self, square: str) -> str:
         """Returns what is on the specified square.
@@ -576,7 +588,7 @@ class Stockfish:
                 The coordinate of the square in question. E.g., e4.
         
         Returns:
-            One of: "P", "p", "R", "r", "N", "n", "B", "b", "Q", "q",
+            One of: "P", "p", "N", "n", "B", "b", "R", "r", "Q", "q",
             "K", "k", or " ".
             Uppercase represents a white piece, lowercase represents a black
             piece, and a single space represents an empty square.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -562,7 +562,7 @@ class Stockfish:
         WHITE_KING = "K"
         BLACK_KING = "k"
 
-    def get_what_is_on_square(self, square: str) -> Piece:
+    def get_what_is_on_square(self, square: str) -> Optional[Piece]:
         """Returns what is on the specified square.
 
         Args:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -548,7 +548,21 @@ class Stockfish:
         """
         self.depth = str(depth_value)
 
-    def get_what_is_on_square(self, square: str) -> str:
+    class Piece(Enum):
+        WHITE_PAWN = "P"
+        BLACK_PAWN = "p"
+        WHITE_KNIGHT = "N"
+        BLACK_KNIGHT = "n"
+        WHITE_BISHOP = "B"
+        BLACK_BISHOP = "b"
+        WHITE_ROOK = "R"
+        BLACK_ROOK = "r"
+        WHITE_QUEEN = "Q"
+        BLACK_QUEEN = "q"
+        WHITE_KING = "K"
+        BLACK_KING = "k"
+
+    def get_what_is_on_square(self, square: str) -> Piece:
         """Returns what is on the specified square.
 
         Args:
@@ -556,10 +570,8 @@ class Stockfish:
                 The coordinate of the square in question. E.g., e4.
 
         Returns:
-            One of: "P", "p", "N", "n", "B", "b", "R", "r", "Q", "q",
-            "K", "k", or " ".
-            Uppercase represents a white piece, lowercase represents a black
-            piece, and a single space represents an empty square.
+            Either one of the 12 enum members in the Piece enum, or the None
+            object if the square is empty.
         """
 
         file_letter = square[0].lower()
@@ -575,7 +587,11 @@ class Stockfish:
                 "square argument to the get_what_is_on_square function isn't valid."
             )
         rank_visual = self.get_board_visual().splitlines()[17 - 2 * rank_num]
-        return rank_visual[2 + (ord(file_letter) - ord("a")) * 4]
+        piece_as_char = rank_visual[2 + (ord(file_letter) - ord("a")) * 4]
+        if piece_as_char == " ":
+            return None
+        else:
+            return Stockfish.Piece(piece_as_char)
 
     class Capture(Enum):
         DIRECT_CAPTURE = "direct capture"
@@ -598,11 +614,14 @@ class Stockfish:
         """
         if not self.is_move_correct(move_value):
             raise ValueError("The proposed move is not valid in the current position.")
-        if self.get_what_is_on_square(move_value[-2:]) != " ":
+        if self.get_what_is_on_square(move_value[-2:]) != None:
             return Stockfish.Capture.DIRECT_CAPTURE
         elif move_value[-2:] == self.get_fen_position().split()[
             3
-        ] and self.get_what_is_on_square(move_value[:2]) in ["P", "p"]:
+        ] and self.get_what_is_on_square(move_value[:2]) in [
+            Stockfish.Piece.WHITE_PAWN,
+            Stockfish.Piece.BLACK_PAWN,
+        ]:
             return Stockfish.Capture.EN_PASSANT
         else:
             return Stockfish.Capture.NO_CAPTURE

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -549,38 +549,45 @@ class Stockfish:
             depth_value: Depth option higher than 1
         """
         self.depth = str(depth_value)
-    
+
     def get_what_is_on_square(self, square: str) -> str:
         """Returns what is on the specified square.
-        
+
         Args:
             square:
                 The coordinate of the square in question. E.g., e4.
-        
+
         Returns:
             One of: "P", "p", "N", "n", "B", "b", "R", "r", "Q", "q",
             "K", "k", or " ".
             Uppercase represents a white piece, lowercase represents a black
             piece, and a single space represents an empty square.
         """
-        
+
         file_letter = square[0].lower()
         rank_num = int(square[1])
-        if (len(square) != 2 or file_letter < 'a' or file_letter > 'h' or
-            square[1] < '1' or square[1] > '8'):
-            raise ValueError("square argument to the get_what_is_on_square function isn't valid.")
+        if (
+            len(square) != 2
+            or file_letter < "a"
+            or file_letter > "h"
+            or square[1] < "1"
+            or square[1] > "8"
+        ):
+            raise ValueError(
+                "square argument to the get_what_is_on_square function isn't valid."
+            )
         rank_visual = self.get_board_visual().splitlines()[17 - 2 * rank_num]
         return rank_visual[2 + (ord(file_letter) - ord("a")) * 4]
 
     def will_move_be_a_capture(self, move_value: str) -> str:
-        """Returns whether the proposed move will be a direct capture, 
+        """Returns whether the proposed move will be a direct capture,
            en passant, or not a capture at all.
-        
+
         Args:
             move_value:
                 The proposed move, in the notation that Stockfish uses.
                 E.g., "e2e4", "g1f3", etc.
-        
+
         Returns:
             "direct capture" if the move will be a direct capture.
             "en passant" if the move is a capture done with en passant.
@@ -590,8 +597,9 @@ class Stockfish:
             raise ValueError("The proposed move is not valid in the current position.")
         if self.get_what_is_on_square(move_value[-2:]) != " ":
             return "direct capture"
-        elif (move_value[-2:] == self.get_fen_position().split()[3] and
-              self.get_what_is_on_square(move_value[:2]) in ['P','p']):
+        elif move_value[-2:] == self.get_fen_position().split()[
+            3
+        ] and self.get_what_is_on_square(move_value[:2]) in ["P", "p"]:
             return "en passant"
         else:
             return "no capture"

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -101,7 +101,7 @@ class Stockfish:
             self._set_option(name, value)
         self.set_fen_position(self.get_fen_position(), False)
         # Getting SF to set the position again, since UCI option(s) have been updated.
-    
+
     def reset_engine_parameters(self) -> None:
         """Resets the stockfish parameters.
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,7 +25,7 @@ class Stockfish:
             "Min Split Depth": 0,
             "Threads": 1,
             "Ponder": "false",
-            "Hash": 16,
+            "Hash": 1024,
             "MultiPV": 1,
             "Skill Level": 20,
             "Move Overhead": 10,
@@ -102,6 +102,19 @@ class Stockfish:
                 new_param_values.update({"UCI_LimitStrength": "false"})
             elif "UCI_Elo" in new_param_values:
                 new_param_values.update({"UCI_LimitStrength": "true"})
+
+        if "Threads" in new_param_values:
+            # Recommended to set the hash param after threads.
+            threads_value = new_param_values["Threads"]
+            del new_param_values["Threads"]
+            hash_value = None
+            if "Hash" in new_param_values:
+                hash_value = new_param_values["Hash"]
+                del new_param_values["Hash"]
+            else:
+                hash_value = self._parameters["Hash"]
+            new_param_values["Threads"] = threads_value
+            new_param_values["Hash"] = hash_value
 
         for name, value in new_param_values.items():
             self._set_option(name, value, True)

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -583,11 +583,24 @@ class Stockfish:
         """
         if not self.is_move_correct(move_value):
             raise ValueError("The proposed move is not valid in the current position.")
-        if self.get_what_is_on_square(move_value[-2:]) != None:
-            return Stockfish.Capture.DIRECT_CAPTURE
+        starting_square_piece = self.get_what_is_on_square(move_value[:2])
+        ending_square_piece = self.get_what_is_on_square(move_value[-2:])
+        if ending_square_piece != None:
+            if self._parameters["UCI_Chess960"] == "false":
+                return Stockfish.Capture.DIRECT_CAPTURE
+            else:
+                # Check for Chess960 castling:
+                castling_pieces = [
+                    [Stockfish.Piece.WHITE_KING, Stockfish.Piece.WHITE_ROOK],
+                    [Stockfish.Piece.BLACK_KING, Stockfish.Piece.BLACK_ROOK],
+                ]
+                if [starting_square_piece, ending_square_piece] in castling_pieces:
+                    return Stockfish.Capture.NO_CAPTURE
+                else:
+                    return Stockfish.Capture.DIRECT_CAPTURE
         elif move_value[-2:] == self.get_fen_position().split()[
             3
-        ] and self.get_what_is_on_square(move_value[:2]) in [
+        ] and starting_square_piece in [
             Stockfish.Piece.WHITE_PAWN,
             Stockfish.Piece.BLACK_PAWN,
         ]:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -72,16 +72,6 @@ class Stockfish:
         """
         return self._parameters
 
-    def reset_parameters(self) -> None:
-        """Resets the stockfish parameters.
-
-        Returns:
-            None
-        """
-        self._parameters = copy.deepcopy(self.default_stockfish_params)
-        for name, value in list(self._parameters.items()):
-            self._set_option(name, value)
-
     def update_engine_parameters(self, new_param_values: dict) -> None:
         """Updates the stockfish parameters.
 
@@ -111,6 +101,14 @@ class Stockfish:
             self._set_option(name, value)
         self.set_fen_position(self.get_fen_position(), False)
         # Getting SF to set the position again, since UCI option(s) have been updated.
+    
+    def reset_engine_parameters(self) -> None:
+        """Resets the stockfish parameters.
+
+        Returns:
+            None
+        """
+        self.update_engine_parameters(self.default_stockfish_params)
 
     def _prepare_for_new_position(self, send_ucinewgame_token: bool = True) -> None:
         if send_ucinewgame_token:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -550,7 +550,7 @@ class Stockfish:
         """
         self.depth = str(depth_value)
     
-    def get_what_is_on_the_square(self, square: str) -> str:
+    def get_what_is_on_square(self, square: str) -> str:
         """Returns what is on the specified square.
         
         Args:
@@ -568,11 +568,11 @@ class Stockfish:
         rank_num_as_string = square[1]
         if (len(square) != 2 or file_letter < 'a' or file_letter > 'h' or
             rank_num_as_string < '1' or rank_num_as_string > '8'):
-            raise ValueError("square argument to the get_what_is_on_the_square function isn't valid.")
+            raise ValueError("square argument to the get_what_is_on_square function isn't valid.")
         for current_rank in self.get_board_visual().splitlines():
             if rank_num_as_string in current_rank:
                 return current_rank[2 + (ord(file_letter) - ord("a")) * 4]
-        raise RuntimeError("Control reached the end of the get_what_is_on_the_square function.")
+        raise RuntimeError("Control reached the end of the get_what_is_on_square function.")
 
     def will_move_be_a_capture(self, move_value: str) -> str:
         """Returns whether the proposed move will be a direct capture, 
@@ -590,10 +590,10 @@ class Stockfish:
         """
         if not self.is_move_correct(move_value):
             raise ValueError("The proposed move is not valid in the current position.")
-        if self.get_what_is_on_the_square(move_value[-2:]) != " ":
+        if self.get_what_is_on_square(move_value[-2:]) != " ":
             return "direct capture"
         elif (move_value[-2:] == self.get_fen_position().split()[3] and
-              self.get_what_is_on_the_square(move_value[:2]) in ['P','p']):
+              self.get_what_is_on_square(move_value[:2]) in ['P','p']):
             return "en passant"
         else:
             return "no capture"

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -574,39 +574,29 @@ class Stockfish:
                 return current_rank[2 + (ord(file_letter) - ord("a")) * 4]
         raise RuntimeError("Control reached the end of the get_what_is_on_the_square function.")
 
-    def will_move_be_a_capture(self, move_value: str) -> bool:
-        """Returns whether the proposed move will be a capture.
+    def will_move_be_a_capture(self, move_value: str) -> str:
+        """Returns whether the proposed move will be a direct capture, 
+           en passant, or not a capture at all.
         
         Args:
             move_value:
                 The proposed move, in the notation that Stockfish uses.
-                I.e., the coordinate of the starting square followed by
-                the coordinate of the destination square. 
-                E.g., e2e4 or g1f3.
+                E.g., "e2e4", "g1f3", etc.
         
         Returns:
-            True if the destination square contains one of the opponent's 
-            pieces or pawns.
-            False if the destination square is empty.
+            "direct capture" if the move will be a direct capture.
+            "en passant" if the move is a capture done with en passant.
+            "no capture" if the move does not capture anything.
         """
         if not self.is_move_correct(move_value):
             raise ValueError("The proposed move is not valid in the current position.")
-        return (self.get_what_is_on_the_square(move_value[-2:]) != " " or
-                self.will_move_be_en_passant(move_value))
-    
-    def will_move_be_en_passant(self, move_value: str) -> bool:
-        """Returns whether the proposed move will be en passant.
-        
-        Args:
-            move_value:
-                The proposed move, in the notation that Stockfish uses (e.g., e5d6).
-        
-        Returns:
-            True if the move will be en passant, False otherwise.
-        """
-        if not self.is_move_correct(move_value):
-            raise ValueError("The proposed move is not valid in the current position.")
-        return move_value == self.get_fen_position().split()[3]
+        if self.get_what_is_on_the_square(move_value[-2:]) != " ":
+            return "direct capture"
+        elif (move_value[-2:] == self.get_fen_position().split()[3] and
+              self.get_what_is_on_the_square(move_value[:2]) in ['P','p']):
+            return "en passant"
+        else:
+            return "no capture"
 
     def get_stockfish_major_version(self):
         """Returns Stockfish engine major version.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -549,28 +549,8 @@ class Stockfish:
             depth_value: Depth option higher than 1
         """
         self.depth = str(depth_value)
-        
-    def will_move_be_a_capture(self, move_value: str) -> bool:
-        """Returns whether the proposed move will be a capture.
-        
-        Args:
-            move_value:
-                The proposed move, in the notation that Stockfish uses.
-                I.e., the coordinate of the starting square followed by
-                the coordinate of the destination square. 
-                E.g., e2e4 or g1f3.
-        
-        Returns:
-            True if the destination square contains one of the opponent's 
-            pieces or pawns.
-            False if the destination square is empty.
-        """
-        
-        if not self.is_move_correct(move_value):
-            raise ValueError("The proposed move is not valid in the current position.")
-        return self.get_what_is_on_square(move_value[-2:]) != " "
     
-    def get_what_is_on_square(self, square: str) -> str:
+    def get_what_is_on_the_square(self, square: str) -> str:
         """Returns what is on the specified square.
         
         Args:
@@ -588,11 +568,45 @@ class Stockfish:
         rank_num_as_string = square[1]
         if (len(square) != 2 or file_letter < 'a' or file_letter > 'h' or
             rank_num_as_string < '1' or rank_num_as_string > '8'):
-            raise ValueError("square argument to the get_what_is_on_square function isn't valid.")
+            raise ValueError("square argument to the get_what_is_on_the_square function isn't valid.")
         for current_rank in self.get_board_visual().splitlines():
             if rank_num_as_string in current_rank:
                 return current_rank[2 + (ord(file_letter) - ord("a")) * 4]
-        raise RuntimeError("Control reached the end of the get_what_is_on_square function.")
+        raise RuntimeError("Control reached the end of the get_what_is_on_the_square function.")
+
+    def will_move_be_a_capture(self, move_value: str) -> bool:
+        """Returns whether the proposed move will be a capture.
+        
+        Args:
+            move_value:
+                The proposed move, in the notation that Stockfish uses.
+                I.e., the coordinate of the starting square followed by
+                the coordinate of the destination square. 
+                E.g., e2e4 or g1f3.
+        
+        Returns:
+            True if the destination square contains one of the opponent's 
+            pieces or pawns.
+            False if the destination square is empty.
+        """
+        if not self.is_move_correct(move_value):
+            raise ValueError("The proposed move is not valid in the current position.")
+        return (self.get_what_is_on_the_square(move_value[-2:]) != " " or
+                self.will_move_be_en_passant(move_value))
+    
+    def will_move_be_en_passant(self, move_value: str) -> bool:
+        """Returns whether the proposed move will be en passant.
+        
+        Args:
+            move_value:
+                The proposed move, in the notation that Stockfish uses (e.g., e5d6).
+        
+        Returns:
+            True if the move will be en passant, False otherwise.
+        """
+        if not self.is_move_correct(move_value):
+            raise ValueError("The proposed move is not valid in the current position.")
+        return move_value == self.get_fen_position().split()[3]
 
     def get_stockfish_major_version(self):
         """Returns Stockfish engine major version.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -565,14 +565,12 @@ class Stockfish:
         """
         
         file_letter = square[0].lower()
-        rank_num_as_string = square[1]
+        rank_num = int(square[1])
         if (len(square) != 2 or file_letter < 'a' or file_letter > 'h' or
-            rank_num_as_string < '1' or rank_num_as_string > '8'):
+            square[1] < '1' or square[1] > '8'):
             raise ValueError("square argument to the get_what_is_on_square function isn't valid.")
-        for current_rank in self.get_board_visual().splitlines():
-            if rank_num_as_string in current_rank:
-                return current_rank[2 + (ord(file_letter) - ord("a")) * 4]
-        raise RuntimeError("Control reached the end of the get_what_is_on_square function.")
+        rank_visual = self.get_board_visual().splitlines()[17 - 2 * rank_num]
+        return rank_visual[2 + (ord(file_letter) - ord("a")) * 4]
 
     def will_move_be_a_capture(self, move_value: str) -> str:
         """Returns whether the proposed move will be a direct capture, 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -57,9 +57,7 @@ class Stockfish:
         if parameters is None:
             parameters = {}
         self._parameters = copy.deepcopy(self.default_stockfish_params)
-        self._parameters.update(parameters)
-        for name, value in list(self._parameters.items()):
-            self._set_option(name, value)
+        self.update_parameters(parameters)
 
         if self.does_current_engine_version_have_wdl_option():
             self._set_option("UCI_ShowWDL", "true", False)
@@ -82,6 +80,24 @@ class Stockfish:
         """
         self._parameters = copy.deepcopy(self.default_stockfish_params)
         for name, value in list(self._parameters.items()):
+            self._set_option(name, value)
+
+    def update_parameters(self, new_param_values: dict) -> None:
+        """Updates the stockfish parameters.
+
+        Args:
+            new_param_values:
+                Contains (key, value) pairs which will be used to update
+                the _parameters dictionary.
+
+        Returns:
+            None
+        """
+        for key in new_param_values:
+            if key not in self._parameters:
+                raise ValueError(f"'{key}' is not a key that exists.")
+        self._parameters.update(new_param_values)
+        for name, value in self._parameters.items():
             self._set_option(name, value)
 
     def _prepare_for_new_position(self, send_ucinewgame_token: bool = True) -> None:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -54,7 +54,7 @@ class Stockfish:
         self.depth = str(depth)
         self.info: str = ""
 
-        self._parameters = {}
+        self._parameters: dict = {}
         self.update_engine_parameters(self._DEFAULT_STOCKFISH_PARAMS)
         self.update_engine_parameters(parameters)
 
@@ -71,7 +71,7 @@ class Stockfish:
         """
         return self._parameters
 
-    def update_engine_parameters(self, new_param_valuesP: dict) -> None:
+    def update_engine_parameters(self, new_param_valuesP: Optional[dict]) -> None:
         """Updates the stockfish parameters.
 
         Args:
@@ -84,6 +84,7 @@ class Stockfish:
         """
         if not new_param_valuesP:
             return
+
         new_param_values = copy.deepcopy(new_param_valuesP)
 
         if len(self._parameters) > 0:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -549,6 +549,48 @@ class Stockfish:
             depth_value: Depth option higher than 1
         """
         self.depth = str(depth_value)
+        
+    def will_move_be_a_capture(self, move: str) -> bool:
+        """Returns whether the proposed move will be a capture.
+        
+        Args:
+            move:
+                The proposed move, in the notation that Stockfish uses.
+                I.e., the coordinate of the starting square followed by
+                the coordinate of the destination square. 
+                E.g., e2e4 or g1f3.
+        
+        Returns:
+            True if the destination square contains one of the opponent's 
+            pieces or pawns.
+            False if the destination square is empty.
+        """
+        
+        # TODO - Call the other function you've written below.
+    
+    def get_what_is_on_square(self, square: str) -> str:
+        """Returns what is on the specified square.
+        
+        Args:
+            square:
+                The coordinate of the square in question. E.g., e4.
+        
+        Returns:
+            One of: "P", "p", "R", "r", "N", "n", "B", "b", "Q", "q",
+            "K", "k", or " ".
+            Uppercase represents a white piece, lowercase represents a black
+            piece, and a single space represents an empty square.
+        """
+        
+        file_letter = square[0].lower()
+        rank_num_as_string = square[1]
+        if (len(square) != 2 or file_letter < 'a' or file_letter > 'h' or
+            rank_num_as_string < '1' or rank_num_as_string > '8'):
+            raise ValueError("square argument to the get_what_is_on_square function isn't valid.")
+        for current_rank in self.get_board_visual().splitlines():
+            if rank_num_as_string in current_rank:
+                return current_rank[2 + (ord(file_letter) - ord("a")) * 4]
+        raise RuntimeError("Control reached the end of the get_what_is_on_square function.")
 
     def get_stockfish_major_version(self):
         """Returns Stockfish engine major version.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -34,7 +34,6 @@ class Stockfish:
             "UCI_Chess960": "false",
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
-            "UCI_ShowWDL": "false",
         }
         self._stockfish = subprocess.Popen(
             path,
@@ -52,13 +51,6 @@ class Stockfish:
 
         self._put("uci")
 
-        self._already_set_the_has_wdl_option_variable = False
-        self._has_wdl_option = self.does_current_engine_version_have_wdl_option()
-        self._already_set_the_has_wdl_option_variable = True
-
-        if not self._has_wdl_option:
-            del self.default_stockfish_params["UCI_ShowWDL"]
-
         self.depth = str(depth)
         self.info: str = ""
 
@@ -68,6 +60,9 @@ class Stockfish:
         self._parameters.update(parameters)
         for name, value in list(self._parameters.items()):
             self._set_option(name, value)
+
+        if self.does_current_engine_version_have_wdl_option():
+            self._set_option("UCI_ShowWDL", "true", False)
 
         self._prepare_for_new_position(True)
 
@@ -109,9 +104,12 @@ class Stockfish:
             raise BrokenPipeError()
         return self._stockfish.stdout.readline().strip()
 
-    def _set_option(self, name: str, value: Any) -> None:
+    def _set_option(
+        self, name: str, value: Any, update_parameters_attribute: bool = True
+    ) -> None:
         self._put(f"setoption name {name} value {value}")
-        self._parameters.update({name: value})
+        if update_parameters_attribute:
+            self._parameters.update({name: value})
         self._is_ready()
 
     def _is_ready(self) -> None:
@@ -327,8 +325,6 @@ class Stockfish:
             raise RuntimeError(
                 "Your version of Stockfish isn't recent enough to have the UCI_ShowWDL option."
             )
-        was_wdl_option_false_before = self._parameters["UCI_ShowWDL"] == "false"
-        self.set_show_wdl_option(True)
         self._go()
         lines = []
         while True:
@@ -339,8 +335,6 @@ class Stockfish:
                 break
         for current_line in reversed(lines):
             if current_line[0] == "bestmove" and current_line[1] == "(none)":
-                if was_wdl_option_false_before:
-                    self.set_show_wdl_option(False)
                 return None
             elif "multipv" in current_line:
                 index_of_multipv = current_line.index("multipv")
@@ -349,8 +343,6 @@ class Stockfish:
                     wdl_stats = []
                     for i in range(1, 4):
                         wdl_stats.append(int(current_line[index_of_wdl + i]))
-                    if was_wdl_option_false_before:
-                        self.set_show_wdl_option(False)
                     return wdl_stats
         raise RuntimeError("Reached the end of the get_wdl_stats function.")
 
@@ -362,8 +354,6 @@ class Stockfish:
             True, if SF has the option -- False otherwise.
         """
 
-        if self._already_set_the_has_wdl_option_variable:
-            return self._has_wdl_option
         self._put("uci")
         while True:
             text = self._read_line()
@@ -372,27 +362,6 @@ class Stockfish:
                 return False
             elif "UCI_ShowWDL" in splitted_text:
                 return True
-
-    def set_show_wdl_option(self, value: bool) -> None:
-        """Sets Stockfish's "UCI_ShowWDL" option to either "true" or "false".
-
-        Args:
-            value:
-              Tells Stockfish whether to set its UCI option "UCI_ShowWDL"
-              to the value "true" or "false".
-
-        Returns:
-            None
-        """
-
-        if not self.does_current_engine_version_have_wdl_option():
-            raise RuntimeError(
-                "Your version of Stockfish isn't recent enough to have the UCI_ShowWDL option."
-            )
-        assert "UCI_ShowWDL" in self._parameters
-        value_as_string = "true" if value else "false"
-        self._parameters["UCI_ShowWDL"] = value_as_string
-        self._set_option("UCI_ShowWDL", value_as_string)
 
     def get_evaluation(self) -> dict:
         """Evaluates current position

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -427,12 +427,12 @@ class TestStockfish:
             else:
                 assert stockfish_2_params[key] == stockfish_1_params[key]
 
-    def test_get_and_update_parameters(self, stockfish):
+    def test_parameters_functions(self, stockfish):
+        old_parameters = stockfish.get_parameters()
         stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100")
         assert stockfish.get_best_move() == "f1g1"  # ensures Chess960 param is false.
         assert stockfish.get_fen_position() == "4rkr1/4p1p1/8/8/8/8/8/5K1R w K - 0 100"
         assert "multipv 1" in stockfish.info
-        old_parameters = stockfish.get_parameters()
         stockfish.update_engine_parameters(
             {
                 "Minimum Thinking Time": 10,
@@ -466,6 +466,9 @@ class TestStockfish:
         stockfish.update_engine_parameters({"Skill Level": 20})
         assert stockfish.get_parameters()["UCI_LimitStrength"] == "false"
         assert stockfish.get_fen_position() == "4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100"
+        stockfish.reset_engine_parameters()
+        assert stockfish.get_parameters() == old_parameters
+        assert stockfish.get_fen_position() == "4rkr1/4p1p1/8/8/8/8/8/5K1R w K - 0 100"
         with pytest.raises(ValueError):
             stockfish.update_engine_parameters({"Not an existing key", "value"})
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -379,6 +379,33 @@ class TestStockfish:
             "d1c2",
         )
 
+    def test_constructor(self, stockfish):
+        # Will also use a new stockfish instance in order to test sending
+        # params to the constructor.
+
+        stockfish_2 = Stockfish(depth=16, parameters={"MultiPV": 2, "Skill Level": 19})
+        stockfish_2.get_best_move()
+        stockfish.get_best_move()
+
+        assert "multipv 2" in stockfish_2.info
+        assert "depth 16" in stockfish_2.info
+        assert stockfish_2.depth == "16"
+        assert "multipv 1" in stockfish.info
+        assert "depth 15" in stockfish.info
+        assert stockfish.depth == "15"
+
+        stockfish_1_params = stockfish.get_parameters()
+        stockfish_2_params = stockfish_2.get_parameters()
+        for key in stockfish_2_params.keys():
+            if key == "MultiPV":
+                assert stockfish_2_params[key] == 2
+                assert stockfish_1_params[key] == 1
+            elif key == "Skill Level":
+                assert stockfish_2_params[key] == 19
+                assert stockfish_1_params[key] == 20
+            else:
+                assert stockfish_2_params[key] == stockfish_1_params[key]
+
     def test_get_and_update_parameters(self, stockfish):
         stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100")
         assert stockfish.get_best_move() == "f1g1"  # ensures Chess960 param is false.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -325,11 +325,16 @@ class TestStockfish:
         ) != stockfish.is_development_build_of_engine()
 
     def test_get_evaluation_cp(self, stockfish):
+        stockfish.set_depth(20)
         stockfish.set_fen_position(
             "r4rk1/pppb1p1p/2nbpqp1/8/3P4/3QBN2/PPP1BPPP/R4RK1 w - - 0 11"
         )
         evaluation = stockfish.get_evaluation()
-        assert evaluation["type"] == "cp" and evaluation["value"] > 0
+        assert (
+            evaluation["type"] == "cp"
+            and evaluation["value"] >= 60
+            and evaluation["value"] <= 150
+        )
 
     def test_get_evaluation_checkmate(self, stockfish):
         stockfish.set_fen_position("1nb1k1n1/pppppppp/8/6r1/5bqK/6r1/8/8 w - - 2 2")

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -581,17 +581,51 @@ class TestStockfish:
         stockfish.set_fen_position(
             "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
         )
-        assert stockfish.get_what_is_on_square("a1") == "R"
-        assert stockfish.get_what_is_on_square("a8") == "r"
-        assert stockfish.get_what_is_on_square("g8") == "k"
-        assert stockfish.get_what_is_on_square("e1") == "K"
-        assert stockfish.get_what_is_on_square("h2") == "P"
-        assert stockfish.get_what_is_on_square("f8") == "r"
-        assert stockfish.get_what_is_on_square("h7") == "p"
+        assert stockfish.get_what_is_on_square("a1") == Stockfish.Piece.WHITE_ROOK
+        assert stockfish.get_what_is_on_square("a8") == Stockfish.Piece.BLACK_ROOK
+        assert stockfish.get_what_is_on_square("g8") == Stockfish.Piece.BLACK_KING
+        assert stockfish.get_what_is_on_square("e1") == Stockfish.Piece.WHITE_KING
+        assert stockfish.get_what_is_on_square("h2") == Stockfish.Piece.WHITE_PAWN
+        assert stockfish.get_what_is_on_square("f8") == Stockfish.Piece.BLACK_ROOK
+        assert stockfish.get_what_is_on_square("d6") == None
+        assert stockfish.get_what_is_on_square("h7") == Stockfish.Piece.BLACK_PAWN
+        assert stockfish.get_what_is_on_square("c3") == Stockfish.Piece.WHITE_KNIGHT
+        assert stockfish.get_what_is_on_square("a3") == Stockfish.Piece.WHITE_BISHOP
+        assert stockfish.get_what_is_on_square("h8") == None
+        assert stockfish.get_what_is_on_square("d1") == Stockfish.Piece.WHITE_QUEEN
+        assert stockfish.get_what_is_on_square("d4") == None
+        assert stockfish.get_what_is_on_square("f6") == Stockfish.Piece.BLACK_KNIGHT
+        assert stockfish.get_what_is_on_square("g7") == Stockfish.Piece.BLACK_BISHOP
+        assert stockfish.get_what_is_on_square("d8") == Stockfish.Piece.BLACK_QUEEN
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("i1")
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("b9")
+
+    def test_13_return_values_from_what_is_on_square(self, stockfish):
+        stockfish.set_fen_position(
+            "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
+        )
+        expected_enum_members = [
+            "WHITE_PAWN",
+            "BLACK_PAWN",
+            "WHITE_KNIGHT",
+            "BLACK_KNIGHT",
+            "WHITE_BISHOP",
+            "BLACK_BISHOP",
+            "WHITE_ROOK",
+            "BLACK_ROOK",
+            "WHITE_QUEEN",
+            "BLACK_QUEEN",
+            "WHITE_KING",
+            "BLACK_KING",
+        ]
+        rows = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        cols = ["1", "2", "3", "4", "5", "6", "7", "8"]
+        for row in rows:
+            for col in cols:
+                val = stockfish.get_what_is_on_square(row + col)
+                assert val == None or val.name in expected_enum_members
 
     def test_will_move_be_a_capture(self, stockfish):
         stockfish.set_fen_position(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -53,7 +53,7 @@ class TestStockfish:
     def test_get_best_move_remaining_time_not_first_move(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move(wtime=1000)
-        assert best_move in ("a2a3", "d1e2", "b1c3")
+        assert best_move in ("d2d4", "a2a3", "d1e2", "b1c3")
         best_move = stockfish.get_best_move(btime=1000)
         assert best_move in ("d2d4", "b1c3")
         best_move = stockfish.get_best_move(wtime=1000, btime=1000)
@@ -243,28 +243,32 @@ class TestStockfish:
         assert stockfish.get_parameters()["UCI_Elo"] == 2850
 
     def test_that_set_skill_level_updates_params(self, stockfish):
-        old_parameters = stockfish._parameters
-        old_skill_level = stockfish._parameters["Skill Level"]
-        stockfish.set_skill_level(1)
-        expected_params = {
-            "Write Debug Log": "false",
+        old_parameters = {
+            "Debug Log File": "",
             "Contempt": 0,
             "Min Split Depth": 0,
             "Threads": 1,
             "Ponder": "false",
             "Hash": 16,
             "MultiPV": 1,
-            "Skill Level": 1,
-            "Move Overhead": 30,
+            "Skill Level": 20,
+            "Move Overhead": 10,
             "Minimum Thinking Time": 20,
-            "Slow Mover": 80,
+            "Slow Mover": 100,
             "UCI_Chess960": "false",
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
         }
-        assert stockfish.get_parameters() == expected_params
-        stockfish.set_skill_level(old_skill_level)
+        stockfish.set_skill_level(1)
+        for name, value in stockfish.get_parameters().items():
+            if name == "Skill Level":
+                assert value == 1
+            else:
+                assert value == old_parameters[name]
+        assert stockfish._DEFAULT_STOCKFISH_PARAMS == old_parameters
+        stockfish.set_skill_level(20)
         assert stockfish.get_parameters() == old_parameters
+        assert stockfish._DEFAULT_STOCKFISH_PARAMS == old_parameters
 
     def test_chess960_position(self, stockfish):
         assert "KQkq" in stockfish.get_fen_position()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -570,7 +570,7 @@ class TestStockfish:
         # Should do nothing, and change neither of the values below.
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
-    
+
     def test_what_is_on_square_and_capture_functions(self, stockfish):
         stockfish.set_fen_position(
             "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
@@ -591,14 +591,3 @@ class TestStockfish:
             stockfish.get_what_is_on_square("i1")
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("b9")
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -572,7 +572,7 @@ class TestStockfish:
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
 
-    def test_what_is_on_square_and_capture_functions(self, stockfish):
+    def test_what_is_on_square(self, stockfish):
         stockfish.set_fen_position(
             "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
         )
@@ -583,12 +583,42 @@ class TestStockfish:
         assert stockfish.get_what_is_on_square("h2") == "P"
         assert stockfish.get_what_is_on_square("f8") == "r"
         assert stockfish.get_what_is_on_square("h7") == "p"
-        assert stockfish.will_move_be_a_capture("c3d5") == "direct capture"
-        assert stockfish.will_move_be_a_capture("e5d6") == "en passant"
-        assert stockfish.will_move_be_a_capture("f1e2") == "no capture"
-        assert stockfish.will_move_be_a_capture("e5f6") == "direct capture"
-        assert stockfish.will_move_be_a_capture("a3d6") == "no capture"
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("i1")
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("b9")
+
+    def test_will_move_be_a_capture(self, stockfish):
+        stockfish.set_fen_position(
+            "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
+        )
+        c3d5_result = stockfish.will_move_be_a_capture("c3d5")
+        assert (
+            c3d5_result is Stockfish.Capture.DIRECT_CAPTURE
+            and c3d5_result.name == "DIRECT_CAPTURE"
+            and c3d5_result.value == "direct capture"
+        )
+        e5d6_result = stockfish.will_move_be_a_capture("e5d6")
+        assert (
+            e5d6_result is Stockfish.Capture.EN_PASSANT
+            and e5d6_result.name == "EN_PASSANT"
+            and e5d6_result.value == "en passant"
+        )
+        f1e2_result = stockfish.will_move_be_a_capture("f1e2")
+        assert (
+            f1e2_result is Stockfish.Capture.NO_CAPTURE
+            and f1e2_result.name == "NO_CAPTURE"
+            and f1e2_result.value == "no capture"
+        )
+        e5f6_result = stockfish.will_move_be_a_capture("e5f6")
+        assert (
+            e5f6_result is Stockfish.Capture.DIRECT_CAPTURE
+            and e5f6_result.name == "DIRECT_CAPTURE"
+            and e5f6_result.value == "direct capture"
+        )
+        a3d6_result = stockfish.will_move_be_a_capture("a3d6")
+        assert (
+            a3d6_result is Stockfish.Capture.NO_CAPTURE
+            and a3d6_result.name == "NO_CAPTURE"
+            and a3d6_result.value == "no capture"
+        )

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -321,7 +321,7 @@ class TestStockfish:
 
     def test_get_stockfish_major_version(self, stockfish):
         assert (
-            stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14)
+            stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14, 15)
         ) != stockfish.is_development_build_of_engine()
 
     def test_get_evaluation_cp(self, stockfish):
@@ -352,6 +352,7 @@ class TestStockfish:
         assert stockfish.get_best_move() in (
             "d1e2",
             "d1c1",
+            "d1c2",
         )
 
     def test_get_parameters(self, stockfish):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -256,8 +256,6 @@ class TestStockfish:
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
         }
-        if stockfish.does_current_engine_version_have_wdl_option():
-            expected_params["UCI_ShowWDL"] = "false"
         assert stockfish.get_parameters() == expected_params
 
     def test_get_board_visual(self, stockfish):
@@ -464,20 +462,26 @@ class TestStockfish:
         stockfish._set_option("MultiPV", 2)
         if stockfish.does_current_engine_version_have_wdl_option():
             stockfish.set_fen_position("7k/4R3/4P1pp/7N/8/8/1q5q/3K4 w - - 0 1")
-            stockfish.set_show_wdl_option(True)
             wdl_stats = stockfish.get_wdl_stats()
             assert wdl_stats[1] > wdl_stats[0] * 7
             assert abs(wdl_stats[0] - wdl_stats[2]) / wdl_stats[0] < 0.1
-            assert stockfish._parameters["UCI_ShowWDL"] == "true"
+
             stockfish.set_fen_position(
                 "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
             )
-            stockfish.set_show_wdl_option(False)
-            wdl_stats = stockfish.get_wdl_stats()
-            assert wdl_stats[1] > wdl_stats[0] * 3.5
-            assert wdl_stats[0] > wdl_stats[2] * 1.8
-            assert stockfish._parameters["UCI_ShowWDL"] == "false"
+            wdl_stats_2 = stockfish.get_wdl_stats()
+            assert wdl_stats_2[1] > wdl_stats_2[0] * 3.5
+            assert wdl_stats_2[0] > wdl_stats_2[2] * 1.8
+
             stockfish.set_fen_position("8/8/8/8/8/6k1/6p1/6K1 w - - 0 1")
+            assert stockfish.get_wdl_stats() is None
+
+            stockfish.set_fen_position(
+                "rnbqkb1r/pp3ppp/3p1n2/1B2p3/3NP3/2N5/PPP2PPP/R1BQK2R b KQkq - 0 6"
+            )
+            assert len(stockfish.get_wdl_stats()) == 3
+
+            stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
             assert stockfish.get_wdl_stats() is None
         else:
             with pytest.raises(RuntimeError):
@@ -486,29 +490,8 @@ class TestStockfish:
     def test_does_current_engine_version_have_wdl_option(self, stockfish):
         if stockfish.get_stockfish_major_version() <= 11:
             assert not stockfish.does_current_engine_version_have_wdl_option()
-            assert "UCI_ShowWDL" not in stockfish._parameters
             with pytest.raises(RuntimeError):
                 stockfish.get_wdl_stats()
-
-    def test_set_show_wdl_option(self, stockfish):
-        stockfish.set_fen_position(
-            "rnbqkb1r/pp3ppp/3p1n2/1B2p3/3NP3/2N5/PPP2PPP/R1BQK2R b KQkq - 0 6"
-        )
-        if stockfish.does_current_engine_version_have_wdl_option():
-            stockfish.set_show_wdl_option(True)
-            assert stockfish._parameters["UCI_ShowWDL"] == "true"
-            assert len(stockfish.get_wdl_stats()) == 3
-            assert stockfish._parameters["UCI_ShowWDL"] == "true"
-            stockfish.set_show_wdl_option(False)
-            assert stockfish._parameters["UCI_ShowWDL"] == "false"
-            stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
-            assert stockfish.get_wdl_stats() is None
-            assert stockfish._parameters["UCI_ShowWDL"] == "false"
-        else:
-            with pytest.raises(RuntimeError):
-                stockfish.set_show_wdl_option(True)
-            with pytest.raises(RuntimeError):
-                stockfish.set_show_wdl_option(False)
 
     def test_benchmark_result_with_defaults(self, stockfish):
         params = stockfish.BenchmarkParameters()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -239,6 +239,8 @@ class TestStockfish:
         assert stockfish.get_parameters()["UCI_Elo"] == 2850
 
     def test_stockfish_constructor_with_custom_params(self, stockfish):
+        old_parameters = stockfish._parameters
+        old_skill_level = stockfish._parameters["Skill Level"]
         stockfish.set_skill_level(1)
         expected_params = {
             "Write Debug Log": "false",
@@ -257,6 +259,23 @@ class TestStockfish:
             "UCI_Elo": 1350,
         }
         assert stockfish.get_parameters() == expected_params
+        stockfish.set_skill_level(old_skill_level)
+        assert stockfish.get_parameters() == old_parameters
+
+    def test_chess_960_position(self, stockfish):
+        old_parameters = stockfish.get_parameters()
+        expected_parameters = stockfish.get_parameters()
+        expected_parameters["UCI_Chess960"] = "true"
+        stockfish._set_option("UCI_Chess960", "true")
+        assert stockfish.get_parameters() == expected_parameters
+        stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100")
+        assert stockfish.get_best_move() == "f1h1"
+        assert stockfish.get_evaluation() == {"type": "mate", "value": 1}
+        stockfish._set_option("UCI_Chess960", "false")
+        assert stockfish.get_parameters() == old_parameters
+        stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100")
+        assert stockfish.get_best_move() == "f1g1"
+        assert stockfish.get_evaluation() == {"type": "mate", "value": 1}
 
     def test_get_board_visual(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -570,3 +570,35 @@ class TestStockfish:
         # Should do nothing, and change neither of the values below.
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
+    
+    def test_what_is_on_square_and_capture_functions(self, stockfish):
+        stockfish.set_fen_position(
+            "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
+        )
+        assert stockfish.get_what_is_on_square("a1") == "R"
+        assert stockfish.get_what_is_on_square("a8") == "r"
+        assert stockfish.get_what_is_on_square("g8") == "k"
+        assert stockfish.get_what_is_on_square("e1") == "K"
+        assert stockfish.get_what_is_on_square("h2") == "P"
+        assert stockfish.get_what_is_on_square("f8") == "r"
+        assert stockfish.get_what_is_on_square("h7") == "p"
+        assert stockfish.will_move_be_a_capture("c3d5") == "direct capture"
+        assert stockfish.will_move_be_a_capture("e5d6") == "en passant"
+        assert stockfish.will_move_be_a_capture("f1e2") == "no capture"
+        assert stockfish.will_move_be_a_capture("e5f6") == "direct capture"
+        assert stockfish.will_move_be_a_capture("a3d6") == "no capture"
+        with pytest.raises(ValueError):
+            stockfish.get_what_is_on_square("i1")
+        with pytest.raises(ValueError):
+            stockfish.get_what_is_on_square("b9")
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    


### PR DESCRIPTION
Closes #88, closes #68;

- A function that says whether a move will be a direct capture, en passant, or not a capture. This function can be used to solve the problem discussed in the linked issue.
- A function that says what's on a given square.
- A function allowing the user to update the engine parameters, on an already created Stockfish instance.
- If the user wants to set the elo rating/skill level to a certain value (in a call to either the constructor or the update function above), then also set UCI_LimitStrength to be true/false respectively.
- If the user updates the engine parameters, call the set_position() function again.
- Get rid of some unneeded code for WDL stuff.
- Update a few default parameters to match with the current stockfish defaults.
- Modify the test_get_evaluation_cp function.
- Update a few tests to get them to pass with SF 15.
- Use the position mentioned in issue #65 to create a test case for Chess960.
- Add a test for the Stockfish constructor.