### PR TITLE
Issue 92 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ from stockfish import Stockfish
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 ```
 
-There are some default engine settings:
+There are some default engine settings used by this wrapper. For increasing Stockfish's strength and speed, the "Threads" and "Hash" parameters can be modified.
 ```python
 {
     "Debug Log File": "",
     "Contempt": 0,
     "Min Split Depth": 0,
-    "Threads": 1,
+    "Threads": 1, # More threads will make the engine stronger, but should be kept at less than the number of logical processors on your computer.
     "Ponder": "false",
-    "Hash": 1024,
+    "Hash": 1024, # 1024 MB for the hash table - you may want to increase/decrease this, depending on how much RAM you want to use. Should also be kept as some power of 2.
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,
@@ -243,11 +243,15 @@ It is an additional custom non-UCI command, mainly for debugging.
 Do not use this command during a search!
 
 ### Get current major version of stockfish engine
+E.g., if the engine being used is Stockfish 14.1 or Stockfish 14, then the function would return 14.
+Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an 
+int with 5 or 6 digits, representing the date the engine was compiled on. 
+For example, 20122 is returned for the development build compiled on January 2, 2022.
 ```python 
 stockfish.get_stockfish_major_version()
 ```
 ```text
-11
+15
 ```
 
 ### Find if the version of Stockfish being used is a development build

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -17,7 +17,7 @@ class Stockfish:
     """Integrates the Stockfish chess engine with Python."""
 
     def __init__(
-        self, path: str = "fairy-stockfish-largeboard_x86-64", depth: int = 15, parameters: dict = None
+        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -234,7 +234,7 @@ class Stockfish:
         if "a   b   c" in board_str:
             # Engine being used is recent enough to have coordinates, so add them:
             board_rep += f"  {board_str}\n"
-        while "Checkers" not in self._read_line(): 
+        while "Checkers" not in self._read_line():
             # Gets rid of the remaining lines in _stockfish.stdout.
             # "Checkers" is in the last line outputted by Stockfish for the "d" command.
             pass

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -17,7 +17,7 @@ class Stockfish:
     """Integrates the Stockfish chess engine with Python."""
 
     def __init__(
-        self, path: str = "stockfish_15_x64_avx2", depth: int = 15, parameters: dict = None
+        self, path: str = "fairy-stockfish-largeboard_x86-64", depth: int = 15, parameters: dict = None
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -46,7 +46,7 @@ class Stockfish:
         self._has_quit_command_been_sent = False
 
         self._stockfish_major_version: int = int(
-            self._read_line().split(" ")[1].split(".")[0]
+            self._read_line().split(" ")[1].split(".")[0].replace("-", "")
         )
 
         self._put("uci")
@@ -230,8 +230,9 @@ class Stockfish:
             if "+" in board_str or "|" in board_str:
                 count_lines += 1
                 board_rep += f"{board_str}\n"
-        if self._stockfish_major_version >= 12:
-            board_str = self._read_line()
+        board_str = self._read_line()
+        if "a   b   c" in board_str:
+            # Engine being used is recent enough to have coordinates, so add them:
             board_rep += f"  {board_str}\n"
         while "Checkers" not in self._read_line(): 
             # Gets rid of the remaining lines in _stockfish.stdout.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -344,7 +344,7 @@ class TestStockfish:
         assert stockfish.get_board_visual() == expected_result
 
         stockfish._put("d")
-        stockfish._read_line() # skip a line
+        stockfish._read_line()  # skip a line
         assert "+---+---+---+" in stockfish._read_line()
         # Tests that the previous call to get_board_visual left no remaining lines to be read. This means
         # the second line read after stockfish._put("d") now will be the +---+---+---+ of the new outputted board.
@@ -355,7 +355,7 @@ class TestStockfish:
             == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         )
         stockfish._put("d")
-        stockfish._read_line() # skip a line
+        stockfish._read_line()  # skip a line
         assert "+---+---+---+" in stockfish._read_line()
 
     def test_get_fen_position_after_some_moves(self, stockfish):
@@ -592,7 +592,7 @@ class TestStockfish:
         stockfish.set_depth(15)
         stockfish._set_option("MultiPV", 2)
         if stockfish.does_current_engine_version_have_wdl_option():
-            stockfish.get_wdl_stats() # Testing that this doesn't raise a RuntimeError.
+            stockfish.get_wdl_stats()  # Testing that this doesn't raise a RuntimeError.
             stockfish.set_fen_position("7k/4R3/4P1pp/7N/8/8/1q5q/3K4 w - - 0 1")
             wdl_stats = stockfish.get_wdl_stats()
             assert wdl_stats[1] > wdl_stats[0] * 7

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -343,11 +343,20 @@ class TestStockfish:
 
         assert stockfish.get_board_visual() == expected_result
 
+        stockfish._put("d")
+        stockfish._read_line() # skip a line
+        assert "+---+---+---+" in stockfish._read_line()
+        # Tests that the previous call to get_board_visual left no remaining lines to be read. This means
+        # the second line read after stockfish._put("d") now will be the +---+---+---+ of the new outputted board.
+
     def test_get_fen_position(self, stockfish):
         assert (
             stockfish.get_fen_position()
             == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         )
+        stockfish._put("d")
+        stockfish._read_line() # skip a line
+        assert "+---+---+---+" in stockfish._read_line()
 
     def test_get_fen_position_after_some_moves(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
@@ -583,6 +592,7 @@ class TestStockfish:
         stockfish.set_depth(15)
         stockfish._set_option("MultiPV", 2)
         if stockfish.does_current_engine_version_have_wdl_option():
+            stockfish.get_wdl_stats() # Testing that this doesn't raise a RuntimeError.
             stockfish.set_fen_position("7k/4R3/4P1pp/7N/8/8/1q5q/3K4 w - - 0 1")
             wdl_stats = stockfish.get_wdl_stats()
             assert wdl_stats[1] > wdl_stats[0] * 7


### PR DESCRIPTION
Resolves #92.

- Discard any remaining _stockfish.stdout lines, if a function is done reading but some lines are left over. Prevents the wdl bug mentioned in issue 92.
- Get rid of '-' chars in the major version, in case there are any. Should fix the second bug mentioned in the issue.
- Update the readme with some explanations in the parameters and major version sections.