### PR TITLE
Put default value for hash back at 16 MB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are some default engine settings used by this wrapper. For increasing Stoc
     "Min Split Depth": 0,
     "Threads": 1, # More threads will make the engine stronger, but should be kept at less than the number of logical processors on your computer.
     "Ponder": "false",
-    "Hash": 1024, # 1024 MB for the hash table - you may want to increase/decrease this, depending on how much RAM you want to use. Should also be kept as some power of 2.
+    "Hash": 16, # Default size is 16 MB. It's recommended that you increase this value, but keep it as some power of 2. E.g., if you're fine using 2 GB of RAM, set Hash to 2048 (11th power of 2).
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,
@@ -159,7 +159,7 @@ stockfish.get_parameters()
     "Min Split Depth": 0,
     "Threads": 1,
     "Ponder": "false",
-    "Hash": 1024,
+    "Hash": 16,
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,7 +25,7 @@ class Stockfish:
             "Min Split Depth": 0,
             "Threads": 1,
             "Ponder": "false",
-            "Hash": 1024,
+            "Hash": 16,
             "MultiPV": 1,
             "Skill Level": 20,
             "Move Overhead": 10,

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -249,7 +249,7 @@ class TestStockfish:
             "Min Split Depth": 0,
             "Threads": 1,
             "Ponder": "false",
-            "Hash": 1024,
+            "Hash": 16,
             "MultiPV": 1,
             "Skill Level": 20,
             "Move Overhead": 10,


### PR DESCRIPTION
Just a small change. My PR from two weeks ago changed the default hash size to 1024. It's probably better for it to go back to 16, but with a note in the readme recommending for the user to increase the size.