### PR TITLE
Invalid fen

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,20 @@ stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT
 stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
 ```
 
-### Invalid FENs
+### StockfishException
 
-If the position is set to an invalid FEN (like ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) and one of functions evaluating the position is called, a ValueError with the text `Stockfish has crashed. This was probably caused by an invalid FEN.` will be raised.
-This error might also occur if the underlying Stockfish process is terminated for some other reason. \
-Not all invalid FENs will result in such an error. For example, positions with pawns on the first rank will still get evaluated.
+The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) is given to Stockfish. \
+Not all invalid inputs will lead to a `StockfishException`, but only those which cause the Stockfish process to crash. \
+To handle a `StockfishException` when using this library, import the `StockfishException` from the library and use a `try/except`-block:
+```python
+from stockfish import StockfishException
+
+try:
+    # Evaluation routine
+
+except StockfishException:
+    # Error handling
+```
 
 ## Testing
 ```bash

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT
 stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
 ```
 
+### Invalid FENs
+
+If the position is set to an invalid FEN (like ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) and one of functions evaluating the position is called, a ValueError with the text `Stockfish has crashed. This was probably caused by an invalid FEN.` will be raised.
+This error might also occur if the underlying Stockfish process is terminated for some other reason. \
+Not all invalid FENs will result in such an error. For example, positions with pawns on the first rank will still get evaluated.
+
 ## Testing
 ```bash
 $ python setup.py test

--- a/stockfish/__init__.py
+++ b/stockfish/__init__.py
@@ -1,1 +1,1 @@
-from .models import Stockfish
+from .models import Stockfish, StockfishException

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -147,6 +147,10 @@ class Stockfish:
     def _read_line(self) -> str:
         if not self._stockfish.stdout:
             raise BrokenPipeError()
+        if self._stockfish.poll() is not None:
+            raise ValueError(
+                "Stockfish has crashed. This was probably caused by an invalid FEN."
+            )
         return self._stockfish.stdout.readline().strip()
 
     def _set_option(

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 from enum import Enum
 
 
+class StockfishException(Exception):
+    pass
+
+
 class Stockfish:
     """Integrates the Stockfish chess engine with Python."""
 
@@ -148,9 +152,7 @@ class Stockfish:
         if not self._stockfish.stdout:
             raise BrokenPipeError()
         if self._stockfish.poll() is not None:
-            raise ValueError(
-                "Stockfish has crashed. This was probably caused by an invalid FEN."
-            )
+            raise StockfishException("The Stockfish process has crashed")
         return self._stockfish.stdout.readline().strip()
 
     def _set_option(

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -783,6 +783,7 @@ class TestStockfish:
             "2k2q2/8/8/8/8/8/8/2Q2K2 w - - 0 1",
             "8/8/8/3k4/3K4/8/8/8 b - - 0 1",
             "1q2nB2/pP1k2KP/NN1Q1qP1/8/1P1p4/4p1br/3R4/6n1 w - - 0 1",
+            "3rk1n1/ppp3pp/8/8/8/8/PPP5/1KR1R3 w - - 0 1",
         ],
     )
     def test_invalid_fen(self, stockfish, fen):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -776,3 +776,17 @@ class TestStockfish:
             and a3d6_result.name == "NO_CAPTURE"
             and a3d6_result.value == "no capture"
         )
+
+    @pytest.mark.parametrize(
+        "fen",
+        [
+            "2k2q2/8/8/8/8/8/8/2Q2K2 w - - 0 1",
+            "8/8/8/3k4/3K4/8/8/8 b - - 0 1",
+            "1q2nB2/pP1k2KP/NN1Q1qP1/8/1P1p4/4p1br/3R4/6n1 w - - 0 1",
+        ],
+    )
+    def test_invalid_fen(self, stockfish, fen):
+        stockfish.set_fen_position(fen)
+
+        with pytest.raises(ValueError):
+            stockfish.get_evaluation()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from timeit import default_timer
 
-from stockfish import Stockfish
+from stockfish import Stockfish, StockfishException
 
 
 class TestStockfish:
@@ -789,5 +789,5 @@ class TestStockfish:
     def test_invalid_fen(self, stockfish, fen):
         stockfish.set_fen_position(fen)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(StockfishException):
             stockfish.get_evaluation()


### PR DESCRIPTION
Fixes #97

### Changes

If the Stockfish process crashes because of an invalid FEN or for some other reason, an error message is raised. I also added a test case for unittesting and an entry in the README.