### PR TITLE
Added parameter to get_board_visual to see the board from black's point of view

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,30 @@ stockfish.get_board_visual()
 +---+---+---+---+---+---+---+---+
   a   b   c   d   e   f   g   h
 ```
+This function has an optional boolean (True by default) as a parameter that indicates whether the board should be seen from the view of white. So it is possible to get the board from black's point of view like this:
+```python 
+stockfish.get_board_visual(False)
+```
+```text
++---+---+---+---+---+---+---+---+
+| R | N | B | K | Q | B | N | R | 1
++---+---+---+---+---+---+---+---+
+| P | P | P | P | P | P | P | P | 2
++---+---+---+---+---+---+---+---+
+|   |   |   |   |   |   |   |   | 3
++---+---+---+---+---+---+---+---+
+|   |   |   |   |   |   |   |   | 4
++---+---+---+---+---+---+---+---+
+|   |   |   |   |   |   |   |   | 5
++---+---+---+---+---+---+---+---+
+|   |   |   |   |   |   |   |   | 6
++---+---+---+---+---+---+---+---+
+| p | p | p | p | p | p | p | p | 7
++---+---+---+---+---+---+---+---+
+| r | n | b | k | q | b | n | r | 8
++---+---+---+---+---+---+---+---+
+  h   g   f   e   d   c   b   a
+```
 
 ### Get current board evaluation in centipawns or mate in x
 ```python 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -233,21 +233,22 @@ class Stockfish:
             String of visual representation of the chessboard with its pieces in current position.
         """
         self._put("d")
-        board_rep = ""
+        board_rep_lines = []
         count_lines = 0
         while count_lines < 17:
             board_str = self._read_line()
             if "+" in board_str or "|" in board_str:
                 count_lines += 1
-                board_rep += f"{board_str}\n"
+                board_rep_lines.append(f"{board_str}")
         board_str = self._read_line()
         if "a   b   c" in board_str:
             # Engine being used is recent enough to have coordinates, so add them:
-            board_rep += f"  {board_str}\n"
+            board_rep_lines.append(f"  {board_str}")
         while "Checkers" not in self._read_line():
             # Gets rid of the remaining lines in _stockfish.stdout.
             # "Checkers" is in the last line outputted by Stockfish for the "d" command.
             pass
+        board_rep = "\n".join(board_rep_lines) + "\n"
         return board_rep
 
     def get_fen_position(self) -> str:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -222,8 +222,12 @@ class Stockfish:
             f"position fen {self.get_fen_position()} moves {self._convert_move_list_to_str(moves)}"
         )
 
-    def get_board_visual(self) -> str:
+    def get_board_visual(self, perspective_white: bool = True) -> str:
         """Returns a visual representation of the current board position.
+
+        Args:
+            perspective_white:
+              A bool that indicates whether the board should be displayed from the perspective of white (True: white, False: black)
 
         Returns:
             String of visual representation of the chessboard with its pieces in current position.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -227,7 +227,8 @@ class Stockfish:
 
         Args:
             perspective_white:
-              A bool that indicates whether the board should be displayed from the perspective of white (True: white, False: black)
+              A bool that indicates whether the board should be displayed from the
+              perspective of white (True: white, False: black)
 
         Returns:
             String of visual representation of the chessboard with its pieces in current position.
@@ -242,7 +243,11 @@ class Stockfish:
                 if perspective_white:
                     board_rep_lines.append(f"{board_str}")
                 else:
+                    # If the board is to be shown from black's point of view, all lines are
+                    # inverted horizontally and at the end the order of the lines is reversed.
                     board_part = board_str[:33]
+                    # To keep the displayed numbers on the right side,
+                    # only the string representing the board is flipped.
                     number_part = board_str[33:] if len(board_str) > 33 else ""
                     board_rep_lines.append(f"{board_part[::-1]}{number_part}")
         if not perspective_white:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -239,11 +239,19 @@ class Stockfish:
             board_str = self._read_line()
             if "+" in board_str or "|" in board_str:
                 count_lines += 1
-                board_rep_lines.append(f"{board_str}")
+                if perspective_white:
+                    board_rep_lines.append(f"{board_str}")
+                else:
+                    board_part = board_str[:33]
+                    number_part = board_str[33:] if len(board_str) > 33 else ""
+                    board_rep_lines.append(f"{board_part[::-1]}{number_part}")
         board_str = self._read_line()
         if "a   b   c" in board_str:
             # Engine being used is recent enough to have coordinates, so add them:
-            board_rep_lines.append(f"  {board_str}")
+            if perspective_white:
+                board_rep_lines.append(f"  {board_str}")
+            else:
+                board_rep_lines.append(f"  {board_str[::-1]}")
         while "Checkers" not in self._read_line():
             # Gets rid of the remaining lines in _stockfish.stdout.
             # "Checkers" is in the last line outputted by Stockfish for the "d" command.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -245,6 +245,8 @@ class Stockfish:
                     board_part = board_str[:33]
                     number_part = board_str[33:] if len(board_str) > 33 else ""
                     board_rep_lines.append(f"{board_part[::-1]}{number_part}")
+        if not perspective_white:
+            board_rep_lines = board_rep_lines[::-1]
         board_str = self._read_line()
         if "a   b   c" in board_str:
             # Engine being used is recent enough to have coordinates, so add them:

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -297,7 +297,7 @@ class TestStockfish:
         assert stockfish.get_evaluation() == {"type": "mate", "value": 1}
         assert stockfish.will_move_be_a_capture("f1g1") is Stockfish.Capture.NO_CAPTURE
 
-    def test_get_board_visual(self, stockfish):
+    def test_get_board_visual_white(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])
         if stockfish.get_stockfish_major_version() >= 12:
             expected_result = (
@@ -342,6 +342,58 @@ class TestStockfish:
             )
 
         assert stockfish.get_board_visual() == expected_result
+
+        stockfish._put("d")
+        stockfish._read_line()  # skip a line
+        assert "+---+---+---+" in stockfish._read_line()
+        # Tests that the previous call to get_board_visual left no remaining lines to be read. This means
+        # the second line read after stockfish._put("d") now will be the +---+---+---+ of the new outputted board.
+
+    def test_get_board_visual_black(self, stockfish):
+        stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])
+        if stockfish.get_stockfish_major_version() >= 12:
+            expected_result = (
+                "+---+---+---+---+---+---+---+---+\n"
+                "| R | N | B | K | Q | B | N | R | 1\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| P | P | P |   |   | P | P | P | 2\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   |   |   |   |   |   | 3\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   | P | P |   |   |   | 4\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   |   | p |   |   |   | 5\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   | p |   |   |   |   | 6\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| p | p | p |   |   | p | p | p | 7\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| r | n | b | k | q | b | n | r | 8\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "  h   g   f   e   d   c   b   a\n"
+            )
+        else:
+            expected_result = (
+                "+---+---+---+---+---+---+---+---+\n"
+                "| R | N | B | K | Q | B | N | R |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| P | P | P |   |   | P | P | P |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   |   |   |   |   |   |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   | P | P |   |   |   |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   |   | p |   |   |   |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "|   |   |   | p |   |   |   |   |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| p | p | p |   |   | p | p | p |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+                "| r | n | b | k | q | b | n | r |\n"
+                "+---+---+---+---+---+---+---+---+\n"
+            )
+
+        assert stockfish.get_board_visual(False) == expected_result
 
         stockfish._put("d")
         stockfish._read_line()  # skip a line


### PR DESCRIPTION
Adds feature suggested in #103 

The `get_board_visual` function can optionally be passed a parameter to see the board from black's point of view.
To make this possible, the board part of the output from Stockfish is inverted both horizontally and vertically. The numbers at the edge and the letters at the bottom are added after the invert, so that they still remain on the right and bottom side respectively.

Test and REAMDE entry added