### PR TITLE
Get the SF process to exit cleanly

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -751,6 +751,5 @@ class Stockfish:
         Stockfish._del_counter += 1
         if self._stockfish.poll() is None:
             self._put("quit")
-            self._stockfish.kill()
             while self._stockfish.poll() is None:
                 pass


### PR DESCRIPTION
Sending the quit command is enough to get the SF process to end, and doing so without kill() lets it "cleanly exit". I found this was needed when trying to profile a Stockfish executable with gprof, since if the executable finishes with kill(), it won't generate a gmon.out file (which contains the profiling data).