### PR TITLE
Configure Github Actions to post coverage on external PRs

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,23 @@
+# .github/workflows/coverage.yml
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Add coverage comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      # Doesn't use actions/checkout@v2 for security reasons
+      - name: Post comment
+        uses: ewjoachim/python-coverage-comment-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          COMMENT_FILENAME: python-coverage-comment-action.txt


### PR DESCRIPTION
I noticed on the last PR that Github Actions is set to not upload coverage comments for external PRs (i.e. those from a fork). This is because there is only read-only access for external PRs.
This PR solves that problem and makes it possible for coverage comments to be displayed on external PRs as well. (See also second part of: https://github.com/ewjoachim/python-coverage-comment-action/issues/15#issuecomment-1166365377) 

I would find it very helpful when developing if already when creating PRs it would be shown how the coverage changes. However, this is just a suggestion. If it doesn't suit your ideas on how coverage should be managed, feel free to close it.