### PR TITLE
Small changes in the is_fen_valid function

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -397,7 +397,7 @@ class Stockfish:
     def is_fen_valid(self, fen: str) -> bool:
         if not Stockfish._is_fen_syntax_valid(fen):
             return False
-        temp_sf = Stockfish(path=self._path)
+        temp_sf = Stockfish(path=self._path, parameters={"Hash": 1})
         # Using a new temporary SF instance, in case the fen is an illegal position that causes
         # the SF process to crash.
         best_move = None
@@ -411,6 +411,11 @@ class Stockfish:
             return False
         else:
             return best_move is not None
+        finally:
+            temp_sf.__del__()
+            # Calling this function before returning from either the except or else block above.
+            # The __del__ function should generally be called implicitly by python when this
+            # temp_sf object goes out of scope, but calling it explicitly guarantees this will happen.
 
     def is_move_correct(self, move_value: str) -> bool:
         """Checks new move.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -892,7 +892,7 @@ class TestStockfish:
             # Since for that FEN, SF 15 actually outputs a best move without crashing (unlike SF 14 and earlier).
             return
         assert not stockfish.is_fen_valid(fen)
-        assert Stockfish._del_counter == old_del_counter + 1
+        assert Stockfish._del_counter == old_del_counter + 2
 
         stockfish.set_fen_position(fen)
         with pytest.raises(StockfishException):
@@ -921,7 +921,7 @@ class TestStockfish:
             assert not stockfish.is_fen_valid(invalid_syntax_fen)
             assert stockfish._is_fen_syntax_valid(correct_fen)
             assert not stockfish._is_fen_syntax_valid(invalid_syntax_fen)
-            assert Stockfish._del_counter == old_del_counter + 1
+            assert Stockfish._del_counter == old_del_counter + 2
 
         time.sleep(2.0)
         assert stockfish._stockfish.poll() is None


### PR DESCRIPTION
- Call `__del__` for the temp object before returning.
- Use a hash of 1 MB instead of 16 for the temp object.