### PR TITLE
Notation conversion, get_num_pieces function, and misc.

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,44 @@
+name: Docs
+
+# build the documentation whenever there are new commits on master
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# security: restrict permissions for CI jobs.
+permissions:
+  contents: read
+
+jobs:
+  # Build the documentation and upload the static HTML files as an artifact.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - run: pip install pdoc
+      - run: pdoc -o docs/ -d google stockfish/models.py
+
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+
+  # Deploy the artifact to GitHub pages.
+  # This is a separate job so that only actions/deploy-pages has the necessary permissions.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: Python Linux ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: Python Windows ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     needs: build-linux
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
       - name: Store coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: .coverage.${{ matrix.python_version }}
@@ -57,9 +57,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
     name: Python Windows ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -72,16 +72,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-linux
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         id: download
         with:
           name: 'coverage'
 
       - name: Coverage comment
         id: coverage_comment
-        uses: ewjoachim/python-coverage-comment-action@v2
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_COVERAGE_FILES: true
@@ -89,7 +89,7 @@ jobs:
           MINIMUM_ORANGE: 80
 
       - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           name: python-coverage-comment-action

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -11,6 +11,10 @@ jobs:
   comment:
     name: Add coverage comment
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       # Doesn't use actions/checkout@v3 for security reasons

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
-      # Doesn't use actions/checkout@v2 for security reasons
+      # Doesn't use actions/checkout@v3 for security reasons
       - name: Post comment
-        uses: ewjoachim/python-coverage-comment-action@v2
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache/
 */*/__pycache__
 coverage.xml
 .coverage
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !LICENSE
 
 /*.exe
+/Notes/
 
 .DS_Store
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+*
+!*.*
+!*/
+!LICENSE
+
+/*.exe
+
 .DS_Store
 *.pyc
 /.idea/

--- a/README.md
+++ b/README.md
@@ -352,12 +352,16 @@ stockfish.get_board_visual(False)
 stockfish.get_evaluation()
 ```
 
-Positive is advantage white, negative is advantage black
+A dictionary is returned representing the evaluation. Two example return values:
 
 ```text
 {"type":"cp", "value":12}
+
 {"type":"mate", "value":-3}
 ```
+
+If stockfish.get_turn_perspective() is True, then the eval value is relative to the side to move.
+Otherwise, positive is advantage white, negative is advantage black.
 
 ### Run benchmark
 

--- a/README.md
+++ b/README.md
@@ -365,8 +365,11 @@ If you discover any security related issues, please report it via the [Private v
 
 ## Status of the project
 
+> **Note**
+> This is just a brief summary. For more information, please look [here](https://github.com/zhelyabuzhsky/stockfish/issues/130).
+
 Due to the [unfortunate death](https://github.com/zhelyabuzhsky/stockfish/pull/112#issuecomment-1367800036) of [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky), the original [repo](https://github.com/zhelyabuzhsky/stockfish) is no longer maintained. For this reason, this fork was created, which continues the project and is currently maintained by [johndoknjas](https://github.com/johndoknjas) and [kieferro](https://github.com/kieferro).
-The official PyPi releases for the [Stockfish package](https://pypi.org/project/stockfish/) will also be created from this repo in the future. [More information about this](https://github.com/pypi/support/issues/2628)
+The official PyPi releases for the [Stockfish package](https://pypi.org/project/stockfish/) will also be created from this repo in the future.
 
 Please submit all bug reports and PRs to this repo instead of the old one.
 

--- a/README.md
+++ b/README.md
@@ -454,6 +454,14 @@ except StockfishException:
     # Error handling
 ```
 
+### Debug view
+
+You can (de-)activate the debug view option with the `set_debug_view` function. Like this you can see all communication between the engine and the library.
+
+```python
+stockfish.set_debug_view(True)
+```
+
 ## Testing
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -471,6 +471,10 @@ stockfish.set_debug_view(True)
 ```bash
 $ python setup.py test
 ```
+To skip some of the slower tests, run:
+```bash
+$ python setup.py skip_slow_tests
+```
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ $ sudo apt install stockfish
 $ brew install stockfish
 ```
 
+## API Documentation
+
+See [API Documentation](https://py-stockfish.github.io/stockfish/) for more information.
+
 ## Features and usage examples
 
 ### Initialize Stockfish class

--- a/README.md
+++ b/README.md
@@ -5,19 +5,20 @@
 
 Implements an easy-to-use Stockfish class to integrates the Stockfish chess engine with Python.
 
-
-
 ## Install
+
 ```bash
 $ pip install stockfish
 ```
 
 #### Ubuntu
+
 ```bash
 $ sudo apt install stockfish
-``` 
+```
 
 #### Mac OS
+
 ```bash
 $ brew install stockfish
 ```
@@ -35,6 +36,7 @@ stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64")
 ```
 
 There are some default engine settings used by this wrapper. For increasing Stockfish's strength and speed, the "Threads" and "Hash" parameters can be modified.
+
 ```python
 {
     "Debug Log File": "",
@@ -55,134 +57,202 @@ There are some default engine settings used by this wrapper. For increasing Stoc
 ```
 
 You can change them, as well as the default search depth, during your Stockfish class initialization:
+
 ```python
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=18, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
 
 These parameters can also be updated at any time by calling the "update_engine_parameters" function:
+
 ```python
 stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
 When you're done using the Stockfish engine process, you can send the "quit" uci command to it with:
+
 ```python
 stockfish.send_quit_command()
 ```
+
 The `__del__()` method of the Stockfish class will call send_quit_command(), but it's technically not guaranteed python will call `__del__()` when the Stockfish object goes out of scope. So even though it'll probably not be needed, it doesn't hurt to call send_quit_command() yourself.
 
 ### Set position by a sequence of moves from the starting position
+
 ```python
 stockfish.set_position(["e2e4", "e7e6"])
 ```
 
 ### Update position by making a sequence of moves from the current position
+
 ```python
 stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 ```
 
 ### Set position by Forsyth–Edwards Notation (FEN)
+
 If you'd like to first check if your fen is valid, call the is_fen_valid() function below.  
 Also, if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
+
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
 ```
 
 ### Check whether the given FEN is valid
+
 This function returns a bool saying whether the passed in FEN is valid (both syntax wise and whether the position represented is legal).  
 The function isn't perfect and won't catch all cases, but generally it should return the correct answer.
-For example, one exception is positions which are legal, but have no legal moves. 
+For example, one exception is positions which are legal, but have no legal moves.
 I.e., for checkmates and stalemates, this function will incorrectly say the fen is invalid.
+
 ```python
 stockfish.is_fen_valid("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
 ```
+
 ```text
 True
 ```
+
 ```python
 stockfish.is_fen_valid("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -") # will return False, in this case because the FEN is missing two of the six required fields.
 ```
+
 ```text
 False
 ```
 
 ### Get best move
+
 ```python
 stockfish.get_best_move()
 ```
+
 ```text
 d2d4
 ```
+
 It's possible to specify remaining time on black and/or white clock. Time is in milliseconds.
+
 ```python
 stockfish.get_best_move(wtime=1000, btime=1000)
 ```
 
 ### Get best move based on a time constraint
+
 ```python
 stockfish.get_best_move_time(1000)
 ```
+
 Time constraint is in milliseconds
+
 ```text
 e2e4
 ```
 
 ### Check is move correct with current position
+
 ```python
 stockfish.is_move_correct('a2a3')
 ```
+
 ```text
 True
 ```
 
 ### Get info on the top n moves
+
+Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa.
+
 ```python
 stockfish.get_top_moves(3)
-```
-```text
-[
-    {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},
-    {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None},
-    {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
-]
+# [
+#   {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},
+#   {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None},
+#   {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
+# ]
 ```
 
-### Get Stockfish's win/draw/loss stats for the side to move in the current position  
+Optional parameter `verbose` (default `False`) specifies whether to include the full info from the engine in the returned dictionary, including SelectiveDepth, Nodes, NodesPerSecond, Time, MultiPVLine, and WDL if available.
+
+```py
+stockfish.get_top_moves(1, verbose=True)
+# [{
+#   "Move":"d6e7",
+#   "Centipawn":-408,
+#   "Mate":"None",
+#   "Nodes":"2767506",
+#   "NodesPerSecond":"526442",
+#   "Time":"5257",
+#   "SelectiveDepth":"31",
+#   "MultiPVLine":"1",
+#   "WDL":"0 0 1000"
+# }]
+```
+
+Optional parameter `num_nodes` specifies the number of nodes to search. If num_nodes is 0, then the engine will search until the configured depth is reached.
+
+### Set perspective of the evaluation
+
+You can set the perspective of the evaluation to be from the perspective of the side to move, or from the perspective of White. Currently this setting only applies to `get_top_moves()`.
+
+```py
+# Set the perspective of the evaluation to be from the point of view of the side to move
+stockfish.set_turn_perspective(True)
+
+# Set the perspective of the evaluation to be from White's perspective
+stockfish.set_turn_perspective(False)
+
+# Get the current perspective of the evaluation
+is_turn_perspective = stockfish.get_turn_perspective()
+
+```
+
+### Get Stockfish's win/draw/loss stats for the side to move in the current position
+
 Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  
 use the "does_current_engine_version_have_wdl_option()" function below.
+
 ```python
 stockfish.get_wdl_stats()
 ```
+
 ```text
 [87, 894, 19]
 ```
 
 ### Find if your version of Stockfish is recent enough to display WDL stats
+
 ```python
 stockfish.does_current_engine_version_have_wdl_option()
 ```
+
 ```text
 True
 ```
 
 ### Set current engine's skill level (ignoring ELO rating)
+
 ```python
 stockfish.set_skill_level(15)
 ```
 
 ### Set current engine's ELO rating (ignoring skill level)
+
 ```python
 stockfish.set_elo_rating(1350)
 ```
 
 ### Set current engine's depth
+
 ```python
 stockfish.set_depth(15)
 ```
 
 ### Get current engine's parameters
+
 ```python
 stockfish.get_parameters()
 ```
+
 ```text
 {
     "Debug Log File": "",
@@ -203,22 +273,27 @@ stockfish.get_parameters()
 ```
 
 ### Reset the engine's parameters to the default
+
 ```python
 stockfish.reset_engine_parameters()
 ```
 
 ### Get current board position in Forsyth–Edwards notation (FEN)
+
 ```python
 stockfish.get_fen_position()
 ```
+
 ```text
 rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
 ```
 
 ### Get current board visual
-```python 
+
+```python
 stockfish.get_board_visual()
 ```
+
 ```text
 +---+---+---+---+---+---+---+---+
 | r | n | b | q | k | b | n | r | 8
@@ -239,10 +314,13 @@ stockfish.get_board_visual()
 +---+---+---+---+---+---+---+---+
   a   b   c   d   e   f   g   h
 ```
+
 This function has an optional boolean (True by default) as a parameter that indicates whether the board should be seen from the view of white. So it is possible to get the board from black's point of view like this:
-```python 
+
+```python
 stockfish.get_board_visual(False)
 ```
+
 ```text
 +---+---+---+---+---+---+---+---+
 | R | N | B | K | Q | B | N | R | 1
@@ -265,10 +343,13 @@ stockfish.get_board_visual(False)
 ```
 
 ### Get current board evaluation in centipawns or mate in x
-```python 
+
+```python
 stockfish.get_evaluation()
 ```
+
 Positive is advantage white, negative is advantage black
+
 ```text
 {"type":"cp", "value":12}
 {"type":"mate", "value":-3}
@@ -277,10 +358,13 @@ Positive is advantage white, negative is advantage black
 ### Run benchmark
 
 #### BenchmarkParameters
+
 ```python
 params = BenchmarkParameters(**kwargs)
 ```
+
 parameters required to run the benchmark function. kwargs can be used to set custom values.
+
 ```text
 ttSize: range(1,128001)
 threads: range(1,513)
@@ -290,38 +374,46 @@ limitType: "depth", "perft", "nodes", "movetime"
 evalType: "mixed", "classical", "NNUE"
 ```
 
-```python 
+```python
 stockfish.benchmark(params)
 ```
+
 This will run the bench command with BenchmarkParameters.
 It is an additional custom non-UCI command, mainly for debugging.
 Do not use this command during a search!
 
 ### Get current major version of stockfish engine
+
 E.g., if the engine being used is Stockfish 14.1 or Stockfish 14, then the function would return 14.
-Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an 
-int with 5 or 6 digits, representing the date the engine was compiled on. 
+Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an
+int with 5 or 6 digits, representing the date the engine was compiled on.
 For example, 20122 is returned for the development build compiled on January 2, 2022.
-```python 
+
+```python
 stockfish.get_stockfish_major_version()
 ```
+
 ```text
 15
 ```
 
 ### Find if the version of Stockfish being used is a development build
+
 ```python
 stockfish.is_development_build_of_engine()
 ```
+
 ```text
 False
 ```
 
 ### Find what is on a certain square
+
 If the square is empty, the None object is returned. Otherwise, one of 12 enum members of a custom  
 Stockfish.Piece enum will be returned. Each of the 12 members of this enum is named in the following pattern:  
-*colour* followed by *underscore* followed by *piece name*, where the colour and piece name are in all caps.  
-For example, say the current position is the starting position:  
+_colour_ followed by _underscore_ followed by _piece name_, where the colour and piece name are in all caps.  
+For example, say the current position is the starting position:
+
 ```python
 stockfish.get_what_is_on_square("e1") # returns Stockfish.Piece.WHITE_KING
 stockfish.get_what_is_on_square("d8") # returns Stockfish.Piece.BLACK_QUEEN
@@ -330,21 +422,24 @@ stockfish.get_what_is_on_square("b5") # returns None
 ```
 
 ### Find if a move will be a capture (and if so, what type of capture)
-The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square).   
+
+The argument must be a string that represents the move, using the notation that Stockfish uses (i.e., the coordinate of the starting square followed by the coordinate of the ending square).  
 The function will return one of the following enum members from a custom Stockfish.Capture enum: DIRECT_CAPTURE, EN_PASSANT, or NO_CAPTURE.  
 For example, say the current position is the one after 1.e4 Nf6 2.Nc3 e6 3.e5 d5.
+
 ```python
-stockfish.will_move_be_a_capture("c3d5")  # returns Stockfish.Capture.DIRECT_CAPTURE  
-stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAPTURE  
-stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT  
-stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
+stockfish.will_move_be_a_capture("c3d5")  # returns Stockfish.Capture.DIRECT_CAPTURE
+stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAPTURE
+stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT
+stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE
 ```
 
 ### StockfishException
 
-The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) is given to Stockfish. \
+The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example `8/8/8/3k4/3K4/8/8/8 w - - 0 1` with both kings next to each other) is given to Stockfish. \
 Not all invalid inputs will lead to a `StockfishException`, but only those which cause the Stockfish process to crash. \
 To handle a `StockfishException` when using this library, import the `StockfishException` from the library and use a `try/except`-block:
+
 ```python
 from stockfish import StockfishException
 
@@ -356,11 +451,13 @@ except StockfishException:
 ```
 
 ## Testing
+
 ```bash
 $ python setup.py test
 ```
 
 ## Security
+
 If you discover any security related issues, please report it via the [Private vulnerability reporting](https://github.com/py-stockfish/stockfish/security) instead of using the issue tracker.
 
 ## Status of the project
@@ -374,8 +471,10 @@ The official PyPi releases for the [Stockfish package](https://pypi.org/project/
 Please submit all bug reports and PRs to this repo instead of the old one.
 
 ## Credits
+
 - We want to sincerely thank [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky), the original founder of this project for writing and maintaining the code and for his contributions to the open source community.
 - We also want to thank all the [other contributors](https://github.com/py-stockfish/stockfish/graphs/contributors) for working on this project.
 
 ## License
+
 MIT License. Please see [License File](https://github.com/py-stockfish/stockfish/blob/master/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -73,10 +73,17 @@ The `__del__()` method of the Stockfish class will call send_quit_command(), but
 ```python
 stockfish.set_position(["e2e4", "e7e6"])
 ```
+If you'd just like to set up the starting position without making any moves from it, just call this function without sending an argument:
+```python
+stockfish.set_position()
+```
 
 ### Update position by making a sequence of moves from the current position
+Function takes a list of strings as its argument. Each string represents a move, and must have the format of the starting coordinate followed by the ending coordinate. If a move leads to a pawn promoting, then an additional character must be appended at the end (to indicate what piece the pawn promotes into).  
+Other types of special moves (e.g., checks, captures, checkmates, en passants) do not need any special notation; the starting coordinate followed by the ending coordinate is all the information that's needed. Note that castling is represented by the starting coordinate of the king followed by the ending coordinate of the king. So "e1g1" would be used for white castling kingside, assuming the white king is still on e1 and castling is legal.  
+Example call (assume in the current position, it is White's turn):
 ```python
-stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
+stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1", "b2b1q"]) # Moves the white piece on g4 to d7, then the black piece on a8 to b8, then the white piece on f1 to d1, and finally pushes the black b2-pawn to b1, promoting it into a queen.
 ```
 
 ### Set position by Forsyth–Edwards Notation (FEN)

--- a/README.md
+++ b/README.md
@@ -353,11 +353,10 @@ The argument is a string representing the move, written in some form that's used
 ```python
 stockfish.convert_human_notation_to_sf_notation("e4xd5") # returns "e4d5"
 ```
-Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following are all valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "Raa6", "R5xa6", "R5a6".
+Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following would all be treated as valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "R5xa6", a5xa6. Note that "Raa6", "R5a6", "a5a6" wouldn't be valid "human-style" notations here, since the move is a capture but there isn't an 'x' indicating this.
 ```python
 stockfish.convert_human_notation_to_sf_notation("Raxa6") # returns "a5a6"
 ```
-It's also valid for the argument to already be in the style Stockfish uses. E.g., sending in "a5a6" to the function just gets "a5a6" back.
 If an invalid argument (bad syntax, or an illegal move) is sent to the function, a ValueError will be raised.
 
 ### StockfishException

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ The argument is a string representing the move, written in some form that's used
 ```python
 stockfish.convert_human_notation_to_sf_notation("e4xd5") # returns "e4d5"
 ```
+For advancing a pawn (e.g., e4-pawn to e5), both "e5" and "e4e5" would be valid arguments to the function. For kingside castling, "0-0", "00", "O-O", "OO" all work (the function's return value for each would be "e1g1").
 Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following would all be treated as valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "R5xa6", a5xa6. Note that "Raa6", "R5a6", "a5a6" wouldn't be valid "human-style" notations here, since the move is a capture but there isn't an 'x' indicating this.
 ```python
 stockfish.convert_human_notation_to_sf_notation("Raxa6") # returns "a5a6"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ stockfish.get_top_moves(3)
 ]
 ```
 
+### Get current board evaluation in centipawns or mate in x
+```python 
+stockfish.get_evaluation()
+```
+Positive is advantage white, negative is advantage black
+```text
+{"type":"cp", "value":12}
+{"type":"mate", "value":-3}
+```
+
 ### Get Stockfish's win/draw/loss stats for the side to move in the current position  
 Before calling this function, it is recommended that you first check if your version of Stockfish is recent enough to display WDL stats. To do this,  
 use the "does_current_engine_version_have_wdl_option()" function below.
@@ -258,16 +268,6 @@ stockfish.get_board_visual(False)
   h   g   f   e   d   c   b   a
 ```
 
-### Get current board evaluation in centipawns or mate in x
-```python 
-stockfish.get_evaluation()
-```
-Positive is advantage white, negative is advantage black
-```text
-{"type":"cp", "value":12}
-{"type":"mate", "value":-3}
-```
-
 ### Run benchmark
 
 #### BenchmarkParameters
@@ -333,6 +333,19 @@ stockfish.will_move_be_a_capture("e5f6")  # returns Stockfish.Capture.DIRECT_CAP
 stockfish.will_move_be_a_capture("e5d6")  # returns Stockfish.Capture.EN_PASSANT  
 stockfish.will_move_be_a_capture("f1e2")  # returns Stockfish.Capture.NO_CAPTURE  
 ```
+
+### Convert human-style notation into the notation Stockfish uses
+The argument is a string representing the move, written in some form that's used by humans. E.g., for using an e4-pawn to capture on d5, a string like
+"e4xd5" or "exd5" could be sent in as a valid argument. The function would then return "e4d5".
+```python
+stockfish.convert_human_notation_to_sf_notation("e4xd5") # returns "e4d5"
+```
+Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following are all valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "Raa6", "R5xa6", "R5a6".
+```python
+stockfish.convert_human_notation_to_sf_notation("Raxa6") # returns "a5a6"
+```
+It's also valid for the argument to already be in the style Stockfish uses. E.g., sending in "a5a6" to the function just gets "a5a6" back.
+If an invalid argument (bad syntax, or an illegal move) is sent to the function, a ValueError will be raised.
 
 ### StockfishException
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There are some default engine settings used by this wrapper. For increasing Stoc
 }
 ```
 
-You can change them, as well as the default search depth, during your Stockfish class initialization:
+You can change them, as well as the search depth, during your Stockfish class initialization:
 ```python
 stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64", depth=18, parameters={"Threads": 2, "Minimum Thinking Time": 30})
 ```
@@ -58,9 +58,9 @@ These parameters can also be updated at any time by calling the "update_engine_p
 stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
-If you'd like to send the "ucinewgame" command to the Stockfish engine process, use this function. The main effect this command has is clearing SF's transposition table, and for most use cases it's probably not worth doing this. Frequently sending this command can end up being a bottleneck.
+As for the depth, it can also be updated, by using the following function. Note that if you don't set depth to a value yourself, the python module will initialize it to 15 by default.
 ```python
-stockfish.send_ucinewgame_command()
+stockfish.set_depth(12)
 ```
 
 When you're done using the Stockfish engine process, you can send the "quit" uci command to it with:
@@ -190,11 +190,6 @@ stockfish.set_skill_level(15)
 stockfish.set_elo_rating(1350)
 ```
 
-### Set current engine's depth
-```python
-stockfish.set_depth(15)
-```
-
 ### Get current engine's parameters
 ```python
 stockfish.get_parameters()
@@ -321,6 +316,12 @@ stockfish.is_development_build_of_engine()
 ```
 ```text
 False
+```
+
+### Send the "ucinewgame" command to the Stockfish engine process. 
+The main effect this command has is clearing SF's transposition table, and for most use cases it's probably not worth doing this. Frequently sending this command can end up being a bottleneck on performance.
+```python
+stockfish.send_ucinewgame_command()
 ```
 
 ### Find what is on a certain square

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ True
 
 ### Get info on the top n moves
 
-Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa.
+Get moves, centipawns, and mates for the top n moves. If the move is a mate, the Centipawn value will be None, and vice versa. Note that if you have stockfish on a weaker elo or skill level setting, the top moves returned by this
+function will still be for full strength.
 
 ```python
 stockfish.get_top_moves(3)
@@ -243,6 +244,11 @@ stockfish.set_skill_level(15)
 
 ```python
 stockfish.set_elo_rating(1350)
+```
+
+### Put the engine back to full strength (if you've previously lowered the ELO or skill level)
+```python
+stockfish.resume_full_strength()
 ```
 
 ### Set the engine's depth
@@ -346,12 +352,13 @@ stockfish.get_board_visual(False)
   h   g   f   e   d   c   b   a
 ```
 
-### Get the current board evaluation in centipawns or mate in x
+### Get the current position's evaluation in centipawns or mate in x
 
 ```python
 stockfish.get_evaluation()
 ```
 
+Stockfish searches to the specified depth and evaluates the current position.
 A dictionary is returned representing the evaluation. Two example return values:
 
 ```text
@@ -362,6 +369,28 @@ A dictionary is returned representing the evaluation. Two example return values:
 
 If stockfish.get_turn_perspective() is True, then the eval value is relative to the side to move.
 Otherwise, positive is advantage white, negative is advantage black.
+
+### Get the current position's 'static evaluation'
+
+```python
+stockfish.get_static_eval()
+```
+
+Sends the 'eval' command to Stockfish. This will get it to 'directly' evaluate the current position 
+(i.e., no search is involved), and output a float value (not a whole number centipawn).
+
+If one side is in check or mated, recent versions of Stockfish will output 'none' for the static eval.
+In this case, the function will return None.
+
+Some example return values:
+
+```text
+-5.27
+
+0.28
+
+None
+```
 
 ### Run benchmark
 

--- a/README.md
+++ b/README.md
@@ -187,17 +187,18 @@ stockfish.does_current_engine_version_have_wdl_option()
 True
 ```
 
-### Set current engine's skill level (ignoring ELO rating)
+### Set engine's current skill level (ignoring ELO rating)
 ```python
 stockfish.set_skill_level(15)
 ```
 
-### Set current engine's ELO rating (ignoring skill level)
+### Set engine's current ELO rating (ignoring skill level)
 ```python
 stockfish.set_elo_rating(1350)
 ```
 
-### Get current engine's parameters
+### Get engine's current parameters
+Returns a deep copy of the dictionary storing the engine's current parameters.
 ```python
 stockfish.get_parameters()
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ These parameters can also be updated at any time by calling the "update_engine_p
 stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
+If you'd like to send the "ucinewgame" command to the Stockfish engine process, use this function. The main effect this command has is clearing SF's transposition table, and for most use cases it's probably not worth doing this. Frequently sending this command can end up being a bottleneck.
+```python
+stockfish.send_ucinewgame_command()
+```
+
 When you're done using the Stockfish engine process, you can send the "quit" uci command to it with:
 ```python
 stockfish.send_quit_command()

--- a/README.md
+++ b/README.md
@@ -328,11 +328,18 @@ stockfish.send_ucinewgame_command()
 If the square is empty, the None object is returned. Otherwise, one of 12 enum members of a custom  
 Stockfish.Piece enum will be returned. Each of the 12 members of this enum is named in the following pattern:  
 *colour* followed by *underscore* followed by *piece name*, where the colour and piece name are in all caps.  
+The value of each enum member is a char representing the piece (uppercase is white, lowercase is black).
+For white, it will be one of "P", "N", "B", "R", "Q", or "K". For black the same chars, except lowercase.
 For example, say the current position is the starting position:  
 ```python
 stockfish.get_what_is_on_square("e1") # returns Stockfish.Piece.WHITE_KING
+stockfish.get_what_is_on_square("e1").value # result is "K"
 stockfish.get_what_is_on_square("d8") # returns Stockfish.Piece.BLACK_QUEEN
+stockfish.get_what_is_on_square("d8").value # result is "q"
 stockfish.get_what_is_on_square("h2") # returns Stockfish.Piece.WHITE_PAWN
+stockfish.get_what_is_on_square("h2").value # result is "P"
+stockfish.get_what_is_on_square("g8") # returns Stockfish.Piece.BLACK_KNIGHT
+stockfish.get_what_is_on_square("g8").value # result is "n"
 stockfish.get_what_is_on_square("b5") # returns None
 ```
 

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ False
 ```
 
 ### Send the "ucinewgame" command to the Stockfish engine process. 
-The main effect this command has is clearing SF's transposition table, and for most use cases it's probably not worth doing this. Frequently sending this command can end up being a bottleneck on performance.
+The main effect this command has is clearing SF's transposition table, and for most use cases there's no need to do this. Frequently sending this command can end up being a bottleneck on performance.
 ```python
 stockfish.send_ucinewgame_command()
 ```

--- a/README.md
+++ b/README.md
@@ -367,6 +367,26 @@ stockfish.convert_human_notation_to_sf_notation("Raxa6") # returns "a5a6"
 ```
 Also, if the move passed to the function is already in Stockfish notation (beginning coordinate followed by ending coordinate, with the promotion piece type if applicable), then it's treated as valid and just returned as is. E.g., in the above case, passing in "a5a6" would also be a valid input (despite not having an 'x' to signify a capture), and the return value is the same "a5a6".
 
+### Get the number of pieces in the current position
+```python
+stockfish.get_num_pieces() # Would return the int 32, if say the current position were the starting chess position.
+```
+This function also has 3 optional arguments, which can be used to give you more specialized info. They are:
+  * specific_file: str  
+    * The default value is just the None object, which gets the function to not deal with any one file, but all 8 of them. If you send a value to this parameter, it should be a string representing a letter between "a" and "h". This will get the function to only count on the specified file.  
+  * specific_rank: int  
+    * Similarly, this parameter allows you to only count on a specific rank, if you wish. The default is again None, which gets the function to count on all the board's 8 ranks. If you send in a value, make it an int between 1 and 8 inclusive.  
+  * pieces_to_count: List  
+    * This parameter allows you to control which pieces are counted. The default value for this parameter is \["P", "N", "B", "R", "Q", "K", "p", "n", "b", "r", "q", "k"\], which gets the function to count all types of pieces. If, for example, you only want to count pawns and white rooks, you can send in \["P", "p", "R"\]. The list can also contain members of the Stockfish.Piece enum, if you'd prefer to use this custom enum of the Stockfish class. E.g., sending in \[Stockfish.Piece.WHITE_PAWN, Stockfish.Piece.BLACK_PAWN, Stockfish.Piece.WHITE_ROOK\] as the argument will yield the same behaviour.  
+
+Some example calls to the function (let's assume the current position is the starting chess position):  
+```python
+stockfish.get_num_pieces(specific_rank=2) # returns 8
+stockfish.get_num_pieces(specific_file="b", pieces_to_count=['N', 'p']) # returns 2, since on the b-file there is one white knight and one black pawn.
+stockfish.get_num_pieces(specific_file="e") # returns 4
+stockfish.get_num_pieces(specific_rank=8, pieces_to_count=[Stockfish.Piece.BLACK_PAWN]) # returns 0, since there are no black pawns on the 8th rank.
+```
+
 ### StockfishException
 
 The `StockfishException` is a newly defined Exception type. It is thrown when the underlying Stockfish process created by the wrapper crashes. This can happen when an incorrect input like an invalid FEN (for example ```8/8/8/3k4/3K4/8/8/8 w - - 0 1``` with both kings next to each other) is given to Stockfish. \

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ e2e4
 ```
 
 ### Check is move correct with current position
+Returns True if the passed in move is legal in the current position.
 ```python
 stockfish.is_move_correct('a2a3')
 ```
@@ -129,14 +130,19 @@ True
 ```
 
 ### Get info on the top n moves
+Returns a list of dictionaries, where each dictionary represents a move's info. Each dictionary will contain a value for the 'Move' key,
+and either the 'Centipawn' or 'Mate' value will be a number (the other will be None). Positive values mean advantage for White, negative means
+advantage for Black. E.g., 'Mate': 3 means that White can mate in three moves, 'Mate': -2 means Black mates in two moves, 'Centipawn': -20 means the
+evaluation is -0.20 (0.20 advantage in Black's favour).
+E.g., for an example position where White is to move, and the top moves are either a mate, winning material, or being slightly worse:
 ```python
 stockfish.get_top_moves(3)
 ```
 ```text
 [
-    {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1},
-    {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None},
-    {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None}
+    {'Move': 'f5h7', 'Centipawn': None, 'Mate': 1}, # the move f5h7 leads to a mate in 1
+    {'Move': 'f5d7', 'Centipawn': 713, 'Mate': None}, # f5d7 leads to an evaluation of +7.13
+    {'Move': 'f5h5', 'Centipawn': -31, 'Mate': None} # f5h5 leads to an evaluation of -0.31
 ]
 ```
 
@@ -144,10 +150,11 @@ stockfish.get_top_moves(3)
 ```python 
 stockfish.get_evaluation()
 ```
-Positive is advantage white, negative is advantage black
+Positive is advantage white, negative is advantage black.
 ```text
-{"type":"cp", "value":12}
-{"type":"mate", "value":-3}
+{"type":"cp", "value":12} # This being the return value would mean White is better by 0.12.
+
+{"type":"mate", "value":-3} # This being the return value would mean Black can checkmate in 3.
 ```
 
 ### Get Stockfish's win/draw/loss stats for the side to move in the current position  

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ There are some default engine settings used by this wrapper. For increasing Stoc
     "Contempt": 0,
     "Min Split Depth": 0,
     "Threads": 1, # More threads will make the engine stronger, but should be kept at less than the number of logical processors on your computer.
-    "Ponder": "false",
+    "Ponder": False,
     "Hash": 16, # Default size is 16 MB. It's recommended that you increase this value, but keep it as some power of 2. E.g., if you're fine using 2 GB of RAM, set Hash to 2048 (11th power of 2).
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,
     "Minimum Thinking Time": 20,
     "Slow Mover": 100,
-    "UCI_Chess960": "false",
-    "UCI_LimitStrength": "false",
+    "UCI_Chess960": False,
+    "UCI_LimitStrength": False,
     "UCI_Elo": 1350
 }
 ```
@@ -65,7 +65,7 @@ stockfish = Stockfish(path="/Users/zhelyabuzhsky/Work/stockfish/stockfish-9-64",
 These parameters can also be updated at any time by calling the "update_engine_parameters" function:
 
 ```python
-stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": "true"}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
+stockfish.update_engine_parameters({"Hash": 2048, "UCI_Chess960": True}) # Gets stockfish to use a 2GB hash table, and also to play Chess960.
 ```
 
 When you're done using the Stockfish engine process, you can send the "quit" uci command to it with:
@@ -91,7 +91,7 @@ stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1"])
 ### Set position by Forsyth–Edwards Notation (FEN)
 
 If you'd like to first check if your fen is valid, call the is_fen_valid() function below.  
-Also, if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
+Also, if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be True, before calling set_fen_position.
 
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
@@ -148,7 +148,7 @@ Time constraint is in milliseconds
 e2e4
 ```
 
-### Check is move correct with current position
+### Check if a move is legal in the current position
 
 ```python
 stockfish.is_move_correct('a2a3')
@@ -229,28 +229,28 @@ stockfish.does_current_engine_version_have_wdl_option()
 True
 ```
 
-### Set current engine's skill level (ignoring ELO rating)
+### Set the engine's skill level (ignoring ELO rating)
 
 ```python
 stockfish.set_skill_level(15)
 ```
 
-### Set current engine's ELO rating (ignoring skill level)
+### Set the engine's ELO rating (ignoring skill level)
 
 ```python
 stockfish.set_elo_rating(1350)
 ```
 
-### Set current engine's depth
+### Set the engine's depth
 
 ```python
 stockfish.set_depth(15)
 ```
 
-### Get current engine's parameters
+### Get the engine's current parameters
 
 ```python
-stockfish.get_parameters()
+stockfish.get_engine_parameters()
 ```
 
 ```text
@@ -259,15 +259,15 @@ stockfish.get_parameters()
     "Contempt": 0,
     "Min Split Depth": 0,
     "Threads": 1,
-    "Ponder": "false",
+    "Ponder": False,
     "Hash": 16,
     "MultiPV": 1,
     "Skill Level": 20,
     "Move Overhead": 10,
     "Minimum Thinking Time": 20,
     "Slow Mover": 100,
-    "UCI_Chess960": "false",
-    "UCI_LimitStrength": "false",
+    "UCI_Chess960": False,
+    "UCI_LimitStrength": False,
     "UCI_Elo": 1350
 }
 ```
@@ -278,7 +278,7 @@ stockfish.get_parameters()
 stockfish.reset_engine_parameters()
 ```
 
-### Get current board position in Forsyth–Edwards notation (FEN)
+### Get the current board position in Forsyth–Edwards notation (FEN)
 
 ```python
 stockfish.get_fen_position()
@@ -288,7 +288,7 @@ stockfish.get_fen_position()
 rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
 ```
 
-### Get current board visual
+### Get the current board visual
 
 ```python
 stockfish.get_board_visual()
@@ -342,7 +342,7 @@ stockfish.get_board_visual(False)
   h   g   f   e   d   c   b   a
 ```
 
-### Get current board evaluation in centipawns or mate in x
+### Get the current board evaluation in centipawns or mate in x
 
 ```python
 stockfish.get_evaluation()
@@ -382,7 +382,7 @@ This will run the bench command with BenchmarkParameters.
 It is an additional custom non-UCI command, mainly for debugging.
 Do not use this command during a search!
 
-### Get current major version of stockfish engine
+### Get the major version of the stockfish engine being used
 
 E.g., if the engine being used is Stockfish 14.1 or Stockfish 14, then the function would return 14.
 Meanwhile, if a development build of the engine is being used (not an official release), then the function returns an

--- a/README.md
+++ b/README.md
@@ -354,11 +354,11 @@ The argument is a string representing the move, written in some form that's used
 stockfish.convert_human_notation_to_sf_notation("e4xd5") # returns "e4d5"
 ```
 For advancing a pawn (e.g., e4-pawn to e5), both "e5" and "e4e5" would be valid arguments to the function. For kingside castling, "0-0", "00", "O-O", "OO" all work (the function's return value for each would be "e1g1").
-Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following would all be treated as valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "R5xa6", a5xa6. Note that "Raa6", "R5a6", "a5a6" wouldn't be valid "human-style" notations here, since the move is a capture but there isn't an 'x' indicating this.
+Or, say there are two rooks on a5 and b6, and an enemy piece on a6. The following would all be treated as valid "human-style" notations for the a5-rook capturing on a6: "Raxa6", "R5xa6", "a5xa6". Note that "Raa6" and "R5a6" wouldn't be valid "human-style" notations here, since the move is a capture but there isn't an 'x' indicating this. If an invalid argument (bad syntax, or an illegal move) is sent to the function, a ValueError will be raised.
 ```python
 stockfish.convert_human_notation_to_sf_notation("Raxa6") # returns "a5a6"
 ```
-If an invalid argument (bad syntax, or an illegal move) is sent to the function, a ValueError will be raised.
+Also, if the move passed to the function is already in Stockfish notation (beginning coordinate followed by ending coordinate, with the promotion piece type if applicable), then it's treated as valid and just returned as is. E.g., in the above case, passing in "a5a6" would also be a valid input (despite not having an 'x' to signify a capture), and the return value is the same "a5a6".
 
 ### StockfishException
 

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ stockfish.send_ucinewgame_command()
 If the square is empty, the None object is returned. Otherwise, one of 12 enum members of a custom  
 Stockfish.Piece enum will be returned. Each of the 12 members of this enum is named in the following pattern:  
 *colour* followed by *underscore* followed by *piece name*, where the colour and piece name are in all caps.  
-The value of each enum member is a char representing the piece (uppercase is white, lowercase is black).
-For white, it will be one of "P", "N", "B", "R", "Q", or "K". For black the same chars, except lowercase.
+The value of each enum member is a char representing the piece (uppercase is white, lowercase is black).  
+For white, it will be one of "P", "N", "B", "R", "Q", or "K". For black the same chars, except lowercase.  
 For example, say the current position is the starting position:  
 ```python
 stockfish.get_what_is_on_square("e1") # returns Stockfish.Piece.WHITE_KING

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Stockfish
+
+> **Note**
+> This section refers to the technical application. If you are looking for information regarding the status of this project and the original repo, please look [here](https://github.com/py-stockfish/stockfish/tree/master#status-of-the-project).
+
 Implements an easy-to-use Stockfish class to integrates the Stockfish chess engine with Python.
+
+
 
 ## Install
 ```bash
@@ -355,11 +361,18 @@ $ python setup.py test
 ```
 
 ## Security
-If you discover any security related issues, please email zhelyabuzhsky@icloud.com instead of using the issue tracker.
+If you discover any security related issues, please report it via the [Private vulnerability reporting](https://github.com/py-stockfish/stockfish/security) instead of using the issue tracker.
+
+## Status of the project
+
+Due to the [unfortunate death](https://github.com/zhelyabuzhsky/stockfish/pull/112#issuecomment-1367800036) of [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky), the original [repo](https://github.com/zhelyabuzhsky/stockfish) is no longer maintained. For this reason, this fork was created, which continues the project and is currently maintained by [johndoknjas](https://github.com/johndoknjas) and [kieferro](https://github.com/kieferro).
+The official PyPi releases for the [Stockfish package](https://pypi.org/project/stockfish/) will also be created from this repo in the future. [More information about this](https://github.com/pypi/support/issues/2628)
+
+Please submit all bug reports and PRs to this repo instead of the old one.
 
 ## Credits
-- [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky)
-- [All Contributors](https://github.com/zhelyabuzhsky/stockfish/graphs/contributors)
+- We want to sincerely thank [Ilya Zhelyabuzhsky](https://github.com/zhelyabuzhsky), the original founder of this project for writing and maintaining the code and for his contributions to the open source community.
+- We also want to thank all the [other contributors](https://github.com/py-stockfish/stockfish/graphs/contributors) for working on this project.
 
 ## License
-MIT License. Please see [License File](https://github.com/zhelyabuzhsky/stockfish/blob/master/LICENSE) for more information.
+MIT License. Please see [License File](https://github.com/py-stockfish/stockfish/blob/master/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -372,19 +372,20 @@ Also, if the move passed to the function is already in Stockfish notation (begin
 stockfish.get_num_pieces() # Would return the int 32, if say the current position were the starting chess position.
 ```
 This function also has 3 optional arguments, which can be used to give you more specialized info. They are:
-  * specific_file: str  
-    * The default value is just the None object, which gets the function to not deal with any one file, but all 8 of them. If you send a value to this parameter, it should be a string representing a letter between "a" and "h". This will get the function to only count on the specified file.  
-  * specific_rank: int  
-    * Similarly, this parameter allows you to only count on a specific rank, if you wish. The default is again None, which gets the function to count on all the board's 8 ranks. If you send in a value, make it an int between 1 and 8 inclusive.  
+  * file_range: List\[str\]  
+    *  This parameter is a list of 2 strings, where each string is a letter between "a" and "h" inclusive. The two strings represent the start and end of the range of files which will be included for the count. The default value is \["a", "h"\], which gets the function to count pieces on all 8 of the board's files.  
+  * rank_range: List\[int\]  
+    * Similarly, this parameter allows you to only count on specific ranks, if you wish. The default value is \[1, 8\], which gets the function to count on all 8 ranks. If you specify a value for this parameter, make it a list of length 2, where the elements are both ints between 1 and 8 inclusive. E.g., rank_range=\[2, 5\] would be to count on just ranks 2, 3, 4, and 5.  
   * pieces_to_count: List  
     * This parameter allows you to control which pieces are counted. The default value for this parameter is \["P", "N", "B", "R", "Q", "K", "p", "n", "b", "r", "q", "k"\], which gets the function to count all types of pieces. If, for example, you only want to count pawns and white rooks, you can send in \["P", "p", "R"\]. The list can also contain members of the Stockfish.Piece enum, if you'd prefer to use this custom enum of the Stockfish class. E.g., sending in \[Stockfish.Piece.WHITE_PAWN, Stockfish.Piece.BLACK_PAWN, Stockfish.Piece.WHITE_ROOK\] as the argument will yield the same behaviour.  
 
 Some example calls to the function (let's assume the current position is the starting chess position):  
 ```python
-stockfish.get_num_pieces(specific_rank=2) # returns 8
-stockfish.get_num_pieces(specific_file="b", pieces_to_count=['N', 'p']) # returns 2, since on the b-file there is one white knight and one black pawn.
-stockfish.get_num_pieces(specific_file="e") # returns 4
-stockfish.get_num_pieces(specific_rank=8, pieces_to_count=[Stockfish.Piece.BLACK_PAWN]) # returns 0, since there are no black pawns on the 8th rank.
+stockfish.get_num_pieces(rank_range=[2, 2]) # returns 8, since the function counts all pieces on just the second rank.
+stockfish.get_num_pieces(file_range=["a", "d"], pieces_to_count=["N", "P", "p"]) # returns 9, since between files a-d, there is one white knight, four white pawns, and four black pawns.
+stockfish.get_num_pieces(file_range=["d", "e"], rank_range=[1, 2]) # returns 4, since in this area there is a white king, queen, and two pawns.
+stockfish.get_num_pieces(rank_range=[1, 6], pieces_to_count=[Stockfish.Piece.BLACK_PAWN]) # returns 0, since currently all the black pawns are on the 7th rank.
+stockfish.get_num_pieces(pieces_to_count=["R", "r"]) # returns 4, since there are 4 rooks on the board.
 ```
 
 ### StockfishException

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ stockfish.make_moves_from_current_position(["g4d7", "a8b8", "f1d1", "b2b1q"]) # 
 ```
 
 ### Set position by Forsyth–Edwards Notation (FEN)
-If you'd like to first check if your fen is valid, call the is_fen_valid() function below.  
-Also, if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
+Note that if you want to play Chess960, it's recommended you first update the "UCI_Chess960" engine parameter to be "true", before calling set_fen_position.
 ```python
 stockfish.set_fen_position("rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2")
 ```
@@ -98,6 +97,11 @@ This function returns a bool saying whether the passed in FEN is valid (both syn
 The function isn't perfect and won't catch all cases, but generally it should return the correct answer.
 For example, one exception is positions which are legal, but have no legal moves. 
 I.e., for checkmates and stalemates, this function will incorrectly say the fen is invalid.
+
+Note that the function checks whether a position is legal by temporarily creating a new Stockfish process, and
+then seeing if it can return a best move (and also not crash). Whatever the outcome may be though, this
+temporary SF process should terminate after the function call.
+
 ```python
 stockfish.is_fen_valid("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,7 @@
 [tool:pytest]
 addopts = -ra -q --cov-report term-missing --cov-branch --cov-report xml --cov-report term
     --cov=stockfish -vv --strict-markers -rfE
-
-[aliases]
-test = pytest
+markers=slow
 
 testpaths =
     tests/stockfish/test_models.py

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,28 @@
 from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+import sys
 
 with open("README.md", "r") as readme:
     long_description = readme.read()
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+
+        sys.exit(pytest.main(self.test_args))
+
+
+class PyTestSkipSlow(PyTest):
+    def finalize_options(self):
+        super(PyTestSkipSlow, self).finalize_options()
+        self.test_args.append("-m not slow")
+
 
 setup(
     name="stockfish",
@@ -34,4 +55,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
+    cmdclass={"test": PyTest, "skip_slow_tests": PyTestSkipSlow},
 )

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,7 +25,10 @@ class Stockfish:
     # Used in test_models: will count how many times the del function is called.
 
     def __init__(
-        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
+        self,
+        path: str = "stockfish",
+        depth: int = 15,
+        parameters: Optional[dict] = None,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -324,7 +327,9 @@ class Stockfish:
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
 
-    def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:
+    def get_best_move(
+        self, wtime: Optional[int] = None, btime: Optional[int] = None
+    ) -> Optional[str]:
         """Returns best move with current position on the board.
         wtime and btime arguments influence the search only if provided.
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -687,9 +687,10 @@ class Stockfish:
         """
         evaluation = dict()
         fen_position = self.get_fen_position()
-        compare = 1 if "w" in fen_position else -1
-        # Stockfish shows advantage relative to current player. This function will instead
-        # use positive to represent advantage white, and negative for advantage black.
+        compare = 1 if self.get_turn_perspective() or ("w" in fen_position) else -1
+        # If the user wants the evaluation specified relative to who is to move, this will be done.
+        # Otherwise, the evaluation will be in terms of white's side (positive meaning advantage white,
+        # negative meaning advantage black).
         self._put(f"position {fen_position}")
         self._go()
         while True:

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -735,7 +735,7 @@ class Stockfish:
             move = move[:-1]
         is_whites_turn = "w" in self.get_fen_position()
         if len(move) == 0:
-            return "Empty move"
+            raise ValueError("Empty move")
         if re.match("^(?:[a-h][1-8]){2}[qrnb]$", move.lower()):
             move = move.lower()
             if self.is_move_correct(move):
@@ -896,27 +896,17 @@ class Stockfish:
             if self.is_move_correct(move):
                 if (
                     isCapture
-                    and turnsInto != ""
-                    and self.get_what_is_on_square(dst) is None
-                ) or (
-                    isCapture
-                    and turnsInto == ""
                     and self.will_move_be_a_capture(move)
                     == Stockfish.Capture.NO_CAPTURE
                 ):
-                    raise ValueError("Move is not a capture")
+                    raise ValueError(f"{move} is not a capture.")
                 elif (
                     not isCapture
-                    and turnsInto != ""
-                    and self.get_what_is_on_square(dst) is not None
-                ) or (
-                    not isCapture
-                    and turnsInto == ""
                     and self.will_move_be_a_capture(move)
                     != Stockfish.Capture.NO_CAPTURE
                 ):
-                    print(
-                        "Warning: Move results in a capture, but capture was not indicated by the move string."
+                    raise ValueError(
+                        f"{move} results in a capture, but there isn't an 'x' indicating this in its notation."
                     )
                 return move
         raise ValueError("Invalid Move")

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -730,18 +730,19 @@ class Stockfish:
             SF uses. E.g., Nf3 might become g1f3.
         """
 
+        move_param = move
         move = move.replace(" ", "").replace("-", "")
         while move[-1:] in ["+", "#"]:
             move = move[:-1]
         is_whites_turn = "w" in self.get_fen_position()
         if len(move) == 0:
-            raise ValueError("Empty move")
+            raise ValueError("Empty move sent in to function.")
         if re.match("^(?:[a-h][1-8]){2}[qrnb]$", move.lower()):
             move = move.lower()
             if self.is_move_correct(move):
                 return move
             else:
-                raise ValueError("Invalid move.")
+                raise ValueError(f"{move_param} is an invalid move.")
         else:
             if move.lower() in ["oo", "00"]:
                 # castle kingside
@@ -789,7 +790,7 @@ class Stockfish:
                 move,
             )
             if match is None:
-                raise ValueError("Not a valid move string.")
+                raise ValueError(f"{move_param} is not a valid move string.")
             groups = match.groups()
             piece = None
 
@@ -899,17 +900,17 @@ class Stockfish:
                     and self.will_move_be_a_capture(move)
                     == Stockfish.Capture.NO_CAPTURE
                 ):
-                    raise ValueError(f"{move} is not a capture.")
+                    raise ValueError(f"{move_param} is not a capture.")
                 elif (
                     not isCapture
                     and self.will_move_be_a_capture(move)
                     != Stockfish.Capture.NO_CAPTURE
                 ):
                     raise ValueError(
-                        f"{move} results in a capture, but there isn't an 'x' indicating this in its notation."
+                        f"{move_param} results in a capture, but there isn't an 'x' indicating this in its notation."
                     )
                 return move
-        raise ValueError("Invalid Move")
+        raise ValueError(f"{move_param} is an invalid move.")
 
     def get_stockfish_major_version(self) -> int:
         """Returns Stockfish engine major version."""

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -13,6 +13,7 @@ from os import path
 from dataclasses import dataclass
 from enum import Enum
 import re
+import warnings
 
 
 class Stockfish:
@@ -237,6 +238,16 @@ class Stockfish:
             cmd += f" btime {btime}"
         self._put(cmd)
 
+    def _on_weaker_setting(self) -> bool:
+        return (
+            self._parameters["UCI_LimitStrength"]
+            or self._parameters["Skill Level"] < 20
+        )
+
+    def _weaker_setting_warning(self, message: str) -> None:
+        """Will issue a warning, referring to the function that calls this one."""
+        warnings.warn(message, stacklevel=3)
+
     def set_fen_position(
         self, fen_position: str, send_ucinewgame_token: bool = True
     ) -> None:
@@ -416,6 +427,17 @@ class Stockfish:
         self.update_engine_parameters(
             {"UCI_LimitStrength": True, "UCI_Elo": elo_rating}
         )
+
+    def resume_full_strength(self) -> None:
+        """Puts Stockfish back to full strength, if you've previously lowered the elo or skill level.
+
+        Returns:
+            `None`
+
+        Example:
+            >>> stockfish.reset_to_full_strength()
+        """
+        self.update_engine_parameters({"UCI_LimitStrength": False, "Skill Level": 20})
 
     def set_depth(self, depth: int = 15) -> None:
         """Sets current depth of Stockfish engine.
@@ -638,6 +660,12 @@ class Stockfish:
             raise RuntimeError(
                 "Your version of Stockfish isn't recent enough to have the UCI_ShowWDL option."
             )
+        if self._on_weaker_setting():
+            self._weaker_setting_warning(
+                """Note that even though you've set Stockfish to play on a weaker elo or skill level,"""
+                + """ get_wdl_stats will still return full strength Stockfish's wdl stats of the position."""
+            )
+
         self._go()
         lines = []
         while True:
@@ -680,19 +708,26 @@ class Stockfish:
                 # the last line SF outputs for the "uci" command.
 
     def get_evaluation(self) -> dict:
-        """Evaluates current position
+        """Searches to the specified depth and evaluates the current position
 
         Returns:
             A dictionary of the current advantage with "type" as "cp" (centipawns) or "mate" (mate in n moves)
         """
-        evaluation = dict()
-        fen_position = self.get_fen_position()
-        compare = 1 if self.get_turn_perspective() or ("w" in fen_position) else -1
+
+        if self._on_weaker_setting():
+            self._weaker_setting_warning(
+                """Note that even though you've set Stockfish to play on a weaker elo or skill level,"""
+                + """ get_evaluation will still return full strength Stockfish's evaluation of the position."""
+            )
+
+        compare = (
+            1 if self.get_turn_perspective() or ("w" in self.get_fen_position()) else -1
+        )
         # If the user wants the evaluation specified relative to who is to move, this will be done.
         # Otherwise, the evaluation will be in terms of white's side (positive meaning advantage white,
         # negative meaning advantage black).
-        self._put(f"position {fen_position}")
         self._go()
+        evaluation = dict()
         while True:
             text = self._read_line()
             splitted_text = text.split(" ")
@@ -705,6 +740,35 @@ class Stockfish:
                         }
             elif splitted_text[0] == "bestmove":
                 return evaluation
+
+    def get_static_eval(self) -> Optional[float]:
+        """Sends the 'eval' command to stockfish to get the static evaluation. The current position is
+           'directly' evaluated -- i.e., no search is involved.
+
+        Returns:
+            A float representing the static eval, unless one side is in check or checkmated,
+            in which case None is returned.
+        """
+
+        # Stockfish gives the static eval from white's perspective:
+        compare = (
+            1
+            if not self.get_turn_perspective() or ("w" in self.get_fen_position())
+            else -1
+        )
+        self._put("eval")
+        while True:
+            text = self._read_line()
+            if text.startswith("Final evaluation") or text.startswith(
+                "Total Evaluation"
+            ):
+                splitted_text = text.split()
+                eval = splitted_text[2]
+                if eval == "none":
+                    assert "(in check)" in text
+                    return None
+                else:
+                    return float(eval) * compare
 
     def get_top_moves(
         self,
@@ -742,12 +806,17 @@ class Stockfish:
         """
         if num_top_moves <= 0:
             raise ValueError("num_top_moves is not a positive number.")
-        # to get number of top moves, we use Stockfish's MultiPV option (ie. multiple principal variations)
+        if self._on_weaker_setting():
+            self._weaker_setting_warning(
+                """Note that even though you've set Stockfish to play on a weaker elo or skill level,"""
+                + """ get_top_moves will still return the top moves of full strength Stockfish."""
+            )
 
         # remember global values
         old_multipv = self._parameters["MultiPV"]
         old_num_nodes = self._num_nodes
 
+        # to get number of top moves, we use Stockfish's MultiPV option (i.e., multiple principal variations).
         # set MultiPV to num_top_moves requested
         if num_top_moves != self._parameters["MultiPV"]:
             self._set_option("MultiPV", num_top_moves)

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -12,7 +12,6 @@ from os import path
 from dataclasses import dataclass
 from enum import Enum
 import re
-import regex
 
 
 class StockfishException(Exception):
@@ -26,7 +25,7 @@ class Stockfish:
     # Used in test_models: will count how many times the del function is called.
 
     def __init__(
-        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
+        self, path: str = "stockfish_15_x64_avx2", depth: int = 15, parameters: dict = None
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -729,7 +728,7 @@ class Stockfish:
         else:
             return Stockfish.Capture.NO_CAPTURE
 
-    def convert_human_notation_into_sf_notation(self, move: str) -> str:
+    def convert_human_notation_to_sf_notation(self, move: str) -> str:
         """
         Args:
             move:
@@ -744,7 +743,7 @@ class Stockfish:
         is_whites_turn = "w" in self.get_fen_position()
         if len(move) == 0:
             return "Empty move"
-        if regex.match("^(?:[a-h][1-8]){2}[qrnb]$", move.lower()):
+        if re.match("^(?:[a-h][1-8]){2}[qrnb]$", move.lower()):
             move = move.lower()
             if self.is_move_correct(move):
                 return move
@@ -793,7 +792,7 @@ class Stockfish:
             # resolve the rest with regex
             # do not allow lower case 'b' in first group because it conflicts with second group
             # allow other lower case letters for convenience
-            match = regex.match(
+            match = re.match(
                 "^([RNBKQrnkq]?)([a-h]?)([1-8]?)(x?)([a-h][1-8])(=?[RNBKQrnbkq]?)$",
                 move,
             )

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,7 +25,7 @@ class Stockfish:
     # Used in test_models: will count how many times the del function is called.
 
     def __init__(
-        self, path: str = "stockfish_15_x64_avx2", depth: int = 15, parameters: dict = None
+        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -740,6 +740,8 @@ class Stockfish:
         """
 
         move = move.replace(" ", "").replace("-", "")
+        while move[-1:] in ["+", "#"]:
+            move = move[:-1]
         is_whites_turn = "w" in self.get_fen_position()
         if len(move) == 0:
             return "Empty move"
@@ -750,9 +752,8 @@ class Stockfish:
             else:
                 raise ValueError("Invalid move.")
         else:
-            # castling
-            if move.lower() == "oo":
-                # castle king side
+            if move.lower() in ["oo", "00"]:
+                # castle kingside
                 # Need to check if it's actually a king there as another piece could also have a valid move.
                 if (
                     is_whites_turn
@@ -770,8 +771,8 @@ class Stockfish:
                     return move
                 else:
                     raise ValueError("Cannot castle kingside.")
-            elif move.lower() == "ooo":
-                # castle queen side
+            elif move.lower() in ["ooo", "000"]:
+                # castle queenside
                 if (
                     is_whites_turn
                     and self.get_what_is_on_square("e1") == Stockfish.Piece.WHITE_KING
@@ -789,9 +790,9 @@ class Stockfish:
                 else:
                     raise ValueError("Cannot castle queenside.")
 
-            # resolve the rest with regex
-            # do not allow lower case 'b' in first group because it conflicts with second group
-            # allow other lower case letters for convenience
+            # Resolve the rest with regex.
+            # Do not allow lower case 'b' in first group because it conflicts with second group.
+            # Allow other lower case letters for convenience.
             match = re.match(
                 "^([RNBKQrnkq]?)([a-h]?)([1-8]?)(x?)([a-h][1-8])(=?[RNBKQrnbkq]?)$",
                 move,
@@ -869,12 +870,12 @@ class Stockfish:
             else:
                 possibleSrc = []
                 # run through all the squares and check all the pieces if they can move to the square
-                for file in range(ord("a"), ord("h") + 1):
-                    file = chr(file)
+                for file_as_unicode_int in range(ord("a"), ord("h") + 1):
+                    file = chr(file_as_unicode_int)
                     if src_file is not None and src_file != file:
                         continue
-                    for rank in range(1, 8 + 1):
-                        rank = str(rank)
+                    for rank_as_int in range(1, 8 + 1):
+                        rank = str(rank_as_int)
                         if src_rank is not None and src_rank != rank:
                             continue
                         src = f"{file}{rank}"

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -258,7 +258,7 @@ class Stockfish:
 
         Returns:
             `None`
-        
+
         Example:
             >>> stockfish.set_fen_position("1nb1k1n1/pppppppp/8/6r1/5bqK/6r1/8/8 w - - 2 2")
         """

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -27,7 +27,10 @@ class Stockfish:
     _PIECE_CHARS = ["P", "N", "B", "R", "Q", "K", "p", "n", "b", "r", "q", "k"]
 
     def __init__(
-        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
+        self,
+        path: str = "stockfish",
+        depth: int = 15,
+        parameters: Optional[dict] = None,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -317,7 +320,9 @@ class Stockfish:
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
 
-    def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:
+    def get_best_move(
+        self, wtime: Optional[int] = None, btime: Optional[int] = None
+    ) -> Optional[str]:
         """Returns best move with current position on the board.
         wtime and btime arguments influence the search only if provided.
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -75,12 +75,12 @@ class Stockfish:
         self._prepare_for_new_position()
 
     def get_parameters(self) -> dict:
-        """Returns current board position.
+        """Returns the engine's current parameters.
 
         Returns:
-            Dictionary of current Stockfish engine's parameters.
+            A deep copy of the self._parameters field.
         """
-        return self._parameters
+        return copy.deepcopy(self._parameters)
 
     def update_engine_parameters(self, new_param_valuesP: Optional[dict]) -> None:
         """Updates the stockfish parameters.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -1079,7 +1079,7 @@ class Stockfish:
                 A string which is the notation for a move, in a format that's used
                 by humans. E.g., stuff like Nf3, bxe5, etc.
         Returns:
-            A string representation the notation for this move, in the form that
+            A string representation of the notation for this move, in the form that
             SF uses. E.g., Nf3 might become g1f3.
         """
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -737,7 +737,7 @@ class Stockfish:
         is_whites_turn = "w" in self.get_fen_position()
         if len(move) == 0:
             raise ValueError("Empty move sent in to function.")
-        if re.match("^(?:[a-h][1-8]){2}[qrnb]$", move.lower()):
+        if re.match("^(?:[a-h][1-8]){2}[qrnb]?$", move.lower()):
             move = move.lower()
             if self.is_move_correct(move):
                 return move

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -718,6 +718,63 @@ class Stockfish:
             return Stockfish.Capture.EN_PASSANT
         else:
             return Stockfish.Capture.NO_CAPTURE
+    
+    def get_num_pieces(self, count_white_pieces: bool = True, count_black_pieces: bool = True,
+                       specific_file: str = None, specific_rank: int = None) -> int:
+        """
+        Parameters
+        ----------
+        count_white_pieces : bool, optional
+            Whether to count white pieces for the total. The default is True.
+        count_black_pieces : bool, optional
+            Whether to count black pieces for the total. The default is True.
+        specific_file : str, optional
+            If only wanting the number of pieces in a given file, this param will
+            be some letter from "a" to "h". The default is None (which means all files
+            in the board are counted).
+        specific_rank : int, optional
+            If only wanting the number of pieces in a given rank, this param will
+            be some int from 1 to 8. The default is None (which means all ranks
+            in the board are counted).
+
+        Returns
+        -------
+        int
+            The number of pieces.
+        """
+        
+        if specific_rank is not None and not (1 <= specific_rank <= 8):
+            raise ValueError(f"{specific_rank} is not in the range of 1 to 8.")
+        
+        pieces_to_count = []
+        num_pieces_counter = 0
+        if count_white_pieces:
+            pieces_to_count.extend(['P', 'N', 'B', 'R', 'Q', 'K'])
+        if count_black_pieces:
+            pieces_to_count.extend(['p', 'n', 'b', 'r', 'q', 'k'])
+
+        if specific_file is None:
+            fen_portion = self.get_fen_position().split()[0]
+            if specific_rank is not None:
+                fen_portion = fen_portion.split("/")[8 - specific_rank]
+            for c in pieces_to_count:
+                num_pieces_counter += fen_portion.count(c)
+        else:
+            specific_file = specific_file.lower()
+            if len(specific_file) != 1:
+                raise ValueError(f"{specific_file} should be a single letter.")
+            if not ("a" <= specific_file <= "h"):
+                raise ValueError(f"{specific_file} is not between 'a' and 'h'.")
+            for rank in range(1, 9):
+                if specific_rank is None or specific_rank == rank:
+                    coordinates = specific_file + str(rank)
+                    piece = self.get_what_is_on_square(coordinates)
+                    if piece is not None and piece.value in pieces_to_count:
+                        num_pieces_counter += 1
+
+        return num_pieces_counter
+    # CONTINUE HERE - Done coding this function, now just test it,
+    # and write stuff for it in the readme.
 
     def convert_human_notation_to_sf_notation(self, move: str) -> str:
         """

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -339,6 +339,9 @@ class TestStockfish:
         assert stockfish.get_engine_parameters() == expected_parameters
         stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/4nK1R w K - 0 100")
         assert stockfish.get_best_move() == "f1h1"
+        stockfish.set_turn_perspective(False)
+        assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
+        stockfish.set_turn_perspective()
         assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
         assert stockfish.will_move_be_a_capture("f1h1") is Stockfish.Capture.NO_CAPTURE
         assert (
@@ -347,6 +350,9 @@ class TestStockfish:
         stockfish.update_engine_parameters({"UCI_Chess960": False})
         assert stockfish.get_engine_parameters() == old_parameters
         assert stockfish.get_best_move() == "f1g1"
+        stockfish.set_turn_perspective(False)
+        assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
+        stockfish.set_turn_perspective()
         assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
         assert stockfish.will_move_be_a_capture("f1g1") is Stockfish.Capture.NO_CAPTURE
 
@@ -493,6 +499,8 @@ class TestStockfish:
 
     def test_get_evaluation_stalemate(self, stockfish):
         stockfish.set_fen_position("1nb1kqn1/pppppppp/8/6r1/5b1K/6r1/8/8 w - - 2 2")
+        assert stockfish.get_evaluation() == {"type": "cp", "value": 0}
+        stockfish.set_turn_perspective(not stockfish.get_turn_perspective())
         assert stockfish.get_evaluation() == {"type": "cp", "value": 0}
 
     def test_set_depth(self, stockfish):
@@ -703,12 +711,15 @@ class TestStockfish:
     def test_turn_perspective(self, stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
+        assert stockfish.get_turn_perspective()
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] > 0
+        assert stockfish.get_evaluation()["value"] > 0
         stockfish.set_turn_perspective(False)
         assert stockfish.get_turn_perspective() is False
         moves = stockfish.get_top_moves(1)
         assert moves[0]["Centipawn"] < 0
+        assert stockfish.get_evaluation()["value"] < 0
 
     def test_turn_perspective_raises_type_error(self, stockfish):
         with pytest.raises(TypeError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -887,7 +887,7 @@ class TestStockfish:
         assert Stockfish._is_fen_syntax_valid(fen)
         if (
             fen == "8/8/8/3k4/3K4/8/8/8 b - - 0 1"
-            and stockfish.get_stockfish_major_version() >= 15
+            and stockfish.get_stockfish_major_version() >= 14
         ):
             # Since for that FEN, SF 15 actually outputs a best move without crashing (unlike SF 14 and earlier).
             return

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -54,6 +54,7 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
+    @pytest.mark.slow
     def test_get_best_move_remaining_time_first_move(self, stockfish):
         best_move = stockfish.get_best_move(wtime=1000)
         assert best_move in ("a2a3", "d2d4", "e2e4", "g1f3", "c2c4")
@@ -81,6 +82,7 @@ class TestStockfish:
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("d2d4", "g1f3")
 
+    @pytest.mark.slow
     def test_get_best_move_remaining_time_not_first_move(self, stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move(wtime=1000)
@@ -765,6 +767,7 @@ class TestStockfish:
             with pytest.raises(ValueError):
                 stockfish.make_moves_from_current_position([invalid_move])
 
+    @pytest.mark.slow
     def test_make_moves_transposition_table_speed(self, stockfish):
         """
         make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
@@ -837,12 +840,14 @@ class TestStockfish:
             with pytest.raises(RuntimeError):
                 stockfish.get_wdl_stats()
 
+    @pytest.mark.slow
     def test_benchmark_result_with_defaults(self, stockfish):
         params = stockfish.BenchmarkParameters()
         result = stockfish.benchmark(params)
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_valid_options(self, stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=64, threads=2, limit=1000, limitType="movetime", evalType="classical"
@@ -851,6 +856,7 @@ class TestStockfish:
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_invalid_options(self, stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=2049,
@@ -864,6 +870,7 @@ class TestStockfish:
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
+    @pytest.mark.slow
     def test_benchmark_result_with_invalid_type(self, stockfish):
         params = {
             "ttSize": 16,
@@ -1016,6 +1023,7 @@ class TestStockfish:
         with pytest.raises(ValueError):
             stockfish.will_move_be_a_capture("c3c5")
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "fen",
         [
@@ -1043,6 +1051,7 @@ class TestStockfish:
         with pytest.raises(StockfishException):
             stockfish.get_evaluation()
 
+    @pytest.mark.slow
     def test_is_fen_valid(self, stockfish):
         old_params = stockfish.get_engine_parameters()
         old_info = stockfish.info

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1010,23 +1010,23 @@ class TestStockfish:
     def test_get_num_pieces(self, stockfish, fen):
         stockfish.set_fen_position(fen)
         assert stockfish.get_num_pieces() == 32
-        assert stockfish.get_num_pieces(specific_file="H") == 4
+        assert stockfish.get_num_pieces(file_range=["h", "H"]) == 4
         assert (
             stockfish.get_num_pieces(
-                specific_file="A",
+                file_range=["a", "a"],
                 pieces_to_count=[Stockfish.Piece.WHITE_PAWN, "r", "P"],
             )
             == 2
         )
-        assert stockfish.get_num_pieces(specific_rank=2) == 8
-        assert stockfish.get_num_pieces(specific_rank=2, pieces_to_count=["p"]) == 0
+        assert stockfish.get_num_pieces(rank_range=[2, 2]) == 8
+        assert stockfish.get_num_pieces(rank_range=[2, 2], pieces_to_count=["p"]) == 0
         assert (
             stockfish.get_num_pieces(
-                specific_rank=2, pieces_to_count=[Stockfish.Piece.BLACK_PAWN]
+                rank_range=[2, 2], pieces_to_count=[Stockfish.Piece.BLACK_PAWN]
             )
             == 0
         )
-        assert stockfish.get_num_pieces(specific_rank=-1, pieces_to_count=[]) == 0
+        assert stockfish.get_num_pieces(rank_range=[-1, -1], pieces_to_count=[]) == 0
 
         expected_num_pieces_per_rank = [8, 8, 0, 0, 0, 0, 8, 8]
         expected_num_pawns_per_rank = [0, 8, 0, 0, 0, 0, 8, 0]
@@ -1037,20 +1037,22 @@ class TestStockfish:
         back_rank_pieces = ["R", "N", "B", "Q", "K", "B", "N", "R"]
 
         for i in range(8):
+            a_file_plus_i = [chr(ord("a") + i), chr(ord("a") + i)]
+            a_file_plus_7_minus_i = [chr(ord("a") + 7 - i), chr(ord("a") + 7 - i)]
             assert (
-                stockfish.get_num_pieces(specific_rank=8 - i)
+                stockfish.get_num_pieces(rank_range=[8 - i, 8 - i])
                 == expected_num_pieces_per_rank[i]
             )
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i, specific_file=chr(ord("a") + i)
+                    rank_range=[8 - i, 8 - i], file_range=a_file_plus_i
                 )
                 == expected_num_pieces_per_rank[i] / 8
             )
 
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i,
+                    rank_range=[8 - i, 8 - i],
                     pieces_to_count=[
                         Stockfish.Piece.WHITE_PAWN,
                         Stockfish.Piece.BLACK_PAWN,
@@ -1060,87 +1062,117 @@ class TestStockfish:
             )
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i,
+                    rank_range=[8 - i, 8 - i],
                     pieces_to_count=["P", "p"],
-                    specific_file=chr(ord("a") + 7 - i),
+                    file_range=a_file_plus_7_minus_i,
                 )
                 == expected_num_pawns_per_rank[i] / 8
             )
 
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i, pieces_to_count=[Stockfish.Piece.WHITE_PAWN]
+                    rank_range=[8 - i, 8 - i],
+                    pieces_to_count=[Stockfish.Piece.WHITE_PAWN],
                 )
                 == expected_num_white_pawns_per_rank[i]
             )
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i,
+                    rank_range=[8 - i, 8 - i],
                     pieces_to_count=["P"],
-                    specific_file=chr(ord("a") + i),
+                    file_range=a_file_plus_i,
                 )
                 == expected_num_white_pawns_per_rank[i] / 8
             )
 
             assert (
-                stockfish.get_num_pieces(specific_rank=8 - i, pieces_to_count=["p"])
+                stockfish.get_num_pieces(
+                    rank_range=[8 - i, 8 - i], pieces_to_count=["p"]
+                )
                 == expected_num_black_pawns_per_rank[i]
             )
             assert (
                 stockfish.get_num_pieces(
-                    specific_rank=8 - i,
+                    rank_range=[8 - i, 8 - i],
                     pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
-                    specific_file=chr(ord("a") + 7 - i),
+                    file_range=a_file_plus_7_minus_i,
                 )
                 == expected_num_black_pawns_per_rank[i] / 8
             )
 
-            assert stockfish.get_num_pieces(specific_file=chr(ord("a") + i)) == 4
+            assert stockfish.get_num_pieces(file_range=a_file_plus_i) == 4
             assert stockfish.get_num_pieces(
-                specific_file=chr(ord("a") + i), specific_rank=8 - i
+                file_range=a_file_plus_i,
+                rank_range=[8 - i, 8 - i],
             ) == (0 if 3 <= 8 - i <= 6 else 1)
 
             assert (
                 stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
+                    file_range=a_file_plus_i,
                     pieces_to_count=[Stockfish.Piece.WHITE_PAWN, "p"],
                 )
                 == 2
             )
             assert stockfish.get_num_pieces(
-                specific_file=chr(ord("a") + i),
-                specific_rank=i + 1,
+                file_range=a_file_plus_i,
+                rank_range=[i + 1, i + 1],
                 pieces_to_count=["P"],
             ) == (1 if i + 1 == 2 else 0)
             assert stockfish.get_num_pieces(
-                specific_file=chr(ord("a") + i),
-                specific_rank=8 - i,
+                file_range=a_file_plus_i,
+                rank_range=[8 - i, 8 - i],
                 pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
             ) == (1 if 8 - i == 7 else 0)
 
             for j in range(len(back_rank_pieces)):
                 i_j_in_sync = (i == j) or (i == 7 - j and i not in [3, 4])
                 assert stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
+                    file_range=a_file_plus_i,
                     pieces_to_count=[
                         back_rank_pieces[j],
                         back_rank_pieces[j].lower(),
                     ],
                 ) == (2 if i_j_in_sync else 0)
                 assert stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
+                    file_range=a_file_plus_i,
                     pieces_to_count=[back_rank_pieces[j]],
                 ) == (1 if i_j_in_sync else 0)
                 assert stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
+                    file_range=a_file_plus_i,
                     pieces_to_count=[back_rank_pieces[j].lower()],
                 ) == (1 if i_j_in_sync else 0)
 
         with pytest.raises(ValueError):
-            stockfish.get_num_pieces(specific_rank=-1)
+            stockfish.get_num_pieces(rank_range=[-1, -1])
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(rank_range=[2, 9])
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(rank_range=[9, 2])
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(file_range=["ah"])
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(file_range=["a", "j"])
         with pytest.raises(ValueError):
             stockfish.get_num_pieces(pieces_to_count=["K", "q", "L"])
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(pieces_to_count=["K", 3, "r"])
         with pytest.raises(ValueError):
             stockfish.get_num_pieces(
                 pieces_to_count=["K", Stockfish.Piece.BLACK_QUEEN, "L"]
             )
+
+    def test_get_num_pieces_custom_ranges(self, stockfish):
+        stockfish.set_fen_position(
+            "r4rk1/pp1bbpp1/1qp2n2/3p4/3PnN1p/1PNQ2P1/PB2PPBP/2R1R1K1 w q - 0 1"
+        )
+        assert stockfish.get_num_pieces() == 30
+        assert stockfish.get_num_pieces(file_range=["a", "d"]) == 14
+        assert stockfish.get_num_pieces(file_range=["a", "d"], rank_range=[1, 4]) == 7
+        assert (
+            stockfish.get_num_pieces(file_range=["f", "h"], pieces_to_count=["P", "p"])
+            == 6
+        )
+        assert (
+            stockfish.get_num_pieces(rank_range=[4, 6], pieces_to_count=["P", "p"]) == 4
+        )
+        assert stockfish.get_num_pieces(rank_range=[7, 8], file_range=["e", "H"]) == 5

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -957,8 +957,12 @@ class TestStockfish:
                 == expected_outputs_2[i]
             )
 
-        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4 b3xd4".split()
-        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4  b3d4".split()
+        input_test_moves_3 = (
+            "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4 b3xd4 b3d4 Nb3xd4".split()
+        )
+        expected_outputs_3 = (
+            "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4  b3d4  b3d4 b3d4".split()
+        )
 
         for i in range(len(input_test_moves_3)):
             assert (
@@ -966,7 +970,7 @@ class TestStockfish:
                 == expected_outputs_3[i]
             )
 
-        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3 b3d4 nbd4".split()
+        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3 nbd4".split()
 
         for move in wrong_test_moves:
             with pytest.raises(ValueError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -873,9 +873,10 @@ class TestStockfish:
         assert Stockfish._is_fen_syntax_valid(fen)
         if (
             fen == "8/8/8/3k4/3K4/8/8/8 b - - 0 1"
-            and stockfish.get_stockfish_major_version() >= 15
+            and not (10 < stockfish.get_stockfish_major_version() < 15)
         ):
-            # Since for that FEN, SF 15 actually outputs a best move without crashing (unlike SF 14 and earlier).
+            # Since for that FEN, SF 15+ and 10- actually output 
+            # a best move without crashing (unlike SFs 11 to 14).
             return
         assert not stockfish.is_fen_valid(fen)
         assert Stockfish._del_counter == old_del_counter + 2

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -980,3 +980,24 @@ class TestStockfish:
         for move in wrong_test_moves:
             with pytest.raises(ValueError):
                 stockfish.convert_human_notation_to_sf_notation(move)
+
+    def test_get_num_pieces(self, stockfish):
+        stockfish.set_fen_position(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        )
+        assert stockfish.get_num_pieces() == 32
+        assert stockfish.get_num_pieces(specific_file="H") == 4
+        assert (
+            stockfish.get_num_pieces(specific_file="A", pieces_to_count=["P", "r", "P"])
+            == 2
+        )
+        assert stockfish.get_num_pieces(specific_rank=2) == 8
+        assert stockfish.get_num_pieces(specific_rank=2, pieces_to_count=["p"]) == 0
+        assert stockfish.get_num_pieces(specific_rank=-1, pieces_to_count=[]) == 0
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(specific_rank=-1)
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(pieces_to_count=["K", "q", "L"])
+
+        # CONTINUE HERE - Test this function more, and also
+        # write stuff in the readme for it.

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -957,8 +957,8 @@ class TestStockfish:
                 == expected_outputs_2[i]
             )
 
-        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbd4 Nfxd4".split()
-        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4 f5d4 ".split()
+        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4".split()
+        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4 ".split()
 
         for i in range(len(input_test_moves_3)):
             assert (
@@ -966,7 +966,7 @@ class TestStockfish:
                 == expected_outputs_3[i]
             )
 
-        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3".split()
+        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3 b3d4 nbd4".split()
 
         for move in wrong_test_moves:
             with pytest.raises(ValueError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from timeit import default_timer
 import time
-import warnings
+from typing import Optional, List
 
 from stockfish import Stockfish, StockfishException
 
@@ -1119,7 +1119,7 @@ class TestStockfish:
         old_info = stockfish.info
         old_depth = stockfish._depth
         old_fen = stockfish.get_fen_position()
-        correct_fens = [
+        correct_fens: List[Optional[str]] = [
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
             "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - 0 8",
             "4k3/8/4K3/8/8/8/8/8 w - - 10 50",
@@ -1187,7 +1187,7 @@ class TestStockfish:
         assert stockfish._pick(line, "multipv") == "1"
         assert stockfish._pick(line, "wdl", 3) == "1000"
 
-    def test_convert_human_notation_to_sf_notation(self, stockfish):
+    def test_convert_human_notation_to_sf_notation(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbbk1nr/pPP1pp1p/1p2B3/2PpPN1Q/3p1B2/1N2Pq2/P4PPP/R3K2R w KQkq d6 0 2"
         )
@@ -1240,7 +1240,7 @@ class TestStockfish:
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b - - 10 20",
         ],
     )
-    def test_get_num_pieces(self, stockfish, fen):
+    def test_get_num_pieces(self, stockfish: Stockfish, fen):
         stockfish.set_fen_position(fen)
         assert stockfish.get_num_pieces() == 32
         assert stockfish.get_num_pieces(file_range=["h", "H"]) == 4
@@ -1389,7 +1389,7 @@ class TestStockfish:
                 pieces_to_count=["K", Stockfish.Piece.BLACK_QUEEN, "L"]
             )
 
-    def test_get_num_pieces_custom_ranges(self, stockfish):
+    def test_get_num_pieces_custom_ranges(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "r4rk1/pp1bbpp1/1qp2n2/3p4/3PnN1p/1PNQ2P1/PB2PPBP/2R1R1K1 w q - 0 1"
         )
@@ -1405,7 +1405,7 @@ class TestStockfish:
         )
         assert stockfish.get_num_pieces(rank_range=[7, 8], file_range=["e", "H"]) == 5
 
-    def test_get_engine_parameters(self, stockfish):
+    def test_get_engine_parameters(self, stockfish: Stockfish):
         params = stockfish.get_engine_parameters()
         params.update({"Skill Level": 10})
         assert params["Skill Level"] == 10

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -981,10 +981,16 @@ class TestStockfish:
             with pytest.raises(ValueError):
                 stockfish.convert_human_notation_to_sf_notation(move)
 
-    def test_get_num_pieces(self, stockfish):
-        stockfish.set_fen_position(
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-        )
+    @pytest.mark.parametrize(
+        "fen",
+        [
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b - - 10 20"
+        ],
+    )
+
+    def test_get_num_pieces(self, stockfish, fen):
+        stockfish.set_fen_position(fen)
         assert stockfish.get_num_pieces() == 32
         assert stockfish.get_num_pieces(specific_file="H") == 4
         assert (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -957,8 +957,8 @@ class TestStockfish:
                 == expected_outputs_2[i]
             )
 
-        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4".split()
-        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4 ".split()
+        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4 b3xd4".split()
+        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4  b3d4".split()
 
         for i in range(len(input_test_moves_3)):
             assert (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -871,11 +871,10 @@ class TestStockfish:
         # involve a king being attacked while it's the opponent's turn.
         old_del_counter = Stockfish._del_counter
         assert Stockfish._is_fen_syntax_valid(fen)
-        if (
-            fen == "8/8/8/3k4/3K4/8/8/8 b - - 0 1"
-            and not (10 < stockfish.get_stockfish_major_version() < 15)
+        if fen == "8/8/8/3k4/3K4/8/8/8 b - - 0 1" and not (
+            10 < stockfish.get_stockfish_major_version() < 15
         ):
-            # Since for that FEN, SF 15+ and 10- actually output 
+            # Since for that FEN, SF 15+ and 10- actually output
             # a best move without crashing (unlike SFs 11 to 14).
             return
         assert not stockfish.is_fen_valid(fen)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -988,16 +988,150 @@ class TestStockfish:
         assert stockfish.get_num_pieces() == 32
         assert stockfish.get_num_pieces(specific_file="H") == 4
         assert (
-            stockfish.get_num_pieces(specific_file="A", pieces_to_count=["P", "r", "P"])
+            stockfish.get_num_pieces(
+                specific_file="A",
+                pieces_to_count=[Stockfish.Piece.WHITE_PAWN, "r", "P"],
+            )
             == 2
         )
         assert stockfish.get_num_pieces(specific_rank=2) == 8
         assert stockfish.get_num_pieces(specific_rank=2, pieces_to_count=["p"]) == 0
+        assert (
+            stockfish.get_num_pieces(
+                specific_rank=2, pieces_to_count=[Stockfish.Piece.BLACK_PAWN]
+            )
+            == 0
+        )
         assert stockfish.get_num_pieces(specific_rank=-1, pieces_to_count=[]) == 0
+
+        expected_num_pieces_per_rank = [8, 8, 0, 0, 0, 0, 8, 8]
+        expected_num_pawns_per_rank = [0, 8, 0, 0, 0, 0, 8, 0]
+
+        expected_num_white_pawns_per_rank = [0, 0, 0, 0, 0, 0, 8, 0]
+        expected_num_black_pawns_per_rank = [0, 8, 0, 0, 0, 0, 0, 0]
+
+        back_rank_pieces = ["R", "N", "B", "Q", "K", "B", "N", "R"]
+
+        for i in range(8):
+            assert (
+                stockfish.get_num_pieces(specific_rank=8 - i)
+                == expected_num_pieces_per_rank[i]
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i, specific_file=chr(ord("a") + i)
+                )
+                == expected_num_pieces_per_rank[i] / 8
+            )
+
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i,
+                    pieces_to_count=[
+                        Stockfish.Piece.WHITE_PAWN,
+                        Stockfish.Piece.BLACK_PAWN,
+                    ],
+                )
+                == expected_num_pawns_per_rank[i]
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i,
+                    pieces_to_count=["P", "p"],
+                    specific_file=chr(ord("a") + 7 - i),
+                )
+                == expected_num_pawns_per_rank[i] / 8
+            )
+
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i, pieces_to_count=[Stockfish.Piece.WHITE_PAWN]
+                )
+                == expected_num_white_pawns_per_rank[i]
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i,
+                    pieces_to_count=["P"],
+                    specific_file=chr(ord("a") + i),
+                )
+                == expected_num_white_pawns_per_rank[i] / 8
+            )
+
+            assert (
+                stockfish.get_num_pieces(specific_rank=8 - i, pieces_to_count=["p"])
+                == expected_num_black_pawns_per_rank[i]
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_rank=8 - i,
+                    pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
+                    specific_file=chr(ord("a") + 7 - i),
+                )
+                == expected_num_black_pawns_per_rank[i] / 8
+            )
+
+            assert stockfish.get_num_pieces(specific_file=chr(ord("a") + i)) == 4
+            assert stockfish.get_num_pieces(
+                specific_file=chr(ord("a") + i), specific_rank=8 - i
+            ) == (0 if 3 <= 8 - i <= 6 else 1)
+
+            assert (
+                stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    pieces_to_count=[Stockfish.Piece.WHITE_PAWN, "p"],
+                )
+                == 2
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    specific_rank=i + 1,
+                    pieces_to_count=["P"],
+                )
+                == (1 if i + 1 == 2 else 0)
+            )
+            assert (
+                stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    specific_rank=8 - i,
+                    pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
+                )
+                == (1 if 8 - i == 7 else 0)
+            )
+
+            for j in range(len(back_rank_pieces)):
+                i_j_in_sync = (i == j) or (i == 7 - j and i not in [3, 4])
+                assert (
+                    stockfish.get_num_pieces(
+                        specific_file=chr(ord("a") + i),
+                        pieces_to_count=[
+                            back_rank_pieces[j],
+                            back_rank_pieces[j].lower(),
+                        ],
+                    )
+                    == (2 if i_j_in_sync else 0)
+                )
+                assert (
+                    stockfish.get_num_pieces(
+                        specific_file=chr(ord("a") + i),
+                        pieces_to_count=[back_rank_pieces[j]],
+                    )
+                    == (1 if i_j_in_sync else 0)
+                )
+                assert (
+                    stockfish.get_num_pieces(
+                        specific_file=chr(ord("a") + i),
+                        pieces_to_count=[back_rank_pieces[j].lower()],
+                    )
+                    == (1 if i_j_in_sync else 0)
+                )
+
         with pytest.raises(ValueError):
             stockfish.get_num_pieces(specific_rank=-1)
         with pytest.raises(ValueError):
             stockfish.get_num_pieces(pieces_to_count=["K", "q", "L"])
-
-        # CONTINUE HERE - Test this function more, and also
-        # write stuff in the readme for it.
+        with pytest.raises(ValueError):
+            stockfish.get_num_pieces(
+                pieces_to_count=["K", Stockfish.Piece.BLACK_QUEEN, "L"]
+            )

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -8,7 +8,7 @@ from stockfish import Stockfish, StockfishException
 
 class TestStockfish:
     @pytest.fixture
-    def stockfish(self):
+    def stockfish(self) -> Stockfish:
         return Stockfish()
 
     def test_constructor_defaults(self):
@@ -41,7 +41,7 @@ class TestStockfish:
         with pytest.raises(TypeError):
             Stockfish(**parameters)
 
-    def test_get_best_move_first_move(self, stockfish):
+    def test_get_best_move_first_move(self, stockfish: Stockfish):
         best_move = stockfish.get_best_move()
         assert best_move in (
             "e2e3",
@@ -51,12 +51,12 @@ class TestStockfish:
             "d2d4",
         )
 
-    def test_get_best_move_time_first_move(self, stockfish):
+    def test_get_best_move_time_first_move(self, stockfish: Stockfish):
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
     @pytest.mark.slow
-    def test_get_best_move_remaining_time_first_move(self, stockfish):
+    def test_get_best_move_remaining_time_first_move(self, stockfish: Stockfish):
         best_move = stockfish.get_best_move(wtime=1000)
         assert best_move in ("a2a3", "d2d4", "e2e4", "g1f3", "c2c4")
         best_move = stockfish.get_best_move(btime=1000)
@@ -66,25 +66,25 @@ class TestStockfish:
         best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
-    def test_set_position_resets_info(self, stockfish):
+    def test_set_position_resets_info(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         stockfish.get_best_move()
         assert stockfish.info != ""
         stockfish.set_position(["e2e4", "e7e6"])
         assert stockfish.info == ""
 
-    def test_get_best_move_not_first_move(self, stockfish):
+    def test_get_best_move_not_first_move(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move()
         assert best_move in ("d2d4", "g1f3")
 
-    def test_get_best_move_time_not_first_move(self, stockfish):
+    def test_get_best_move_time_not_first_move(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move_time(1000)
         assert best_move in ("d2d4", "g1f3")
 
     @pytest.mark.slow
-    def test_get_best_move_remaining_time_not_first_move(self, stockfish):
+    def test_get_best_move_remaining_time_not_first_move(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         best_move = stockfish.get_best_move(wtime=1000)
         assert best_move in ("d2d4", "a2a3", "d1e2", "b1c3")
@@ -95,41 +95,41 @@ class TestStockfish:
         best_move = stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000)
         assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
-    def test_get_best_move_checkmate(self, stockfish):
+    def test_get_best_move_checkmate(self, stockfish: Stockfish):
         stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
         assert stockfish.get_best_move() is None
 
-    def test_get_best_move_time_checkmate(self, stockfish):
+    def test_get_best_move_time_checkmate(self, stockfish: Stockfish):
         stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
         assert stockfish.get_best_move_time(1000) is None
 
-    def test_get_best_move_remaining_time_checkmate(self, stockfish):
+    def test_get_best_move_remaining_time_checkmate(self, stockfish: Stockfish):
         stockfish.set_position(["f2f3", "e7e5", "g2g4", "d8h4"])
         assert stockfish.get_best_move(wtime=1000) is None
         assert stockfish.get_best_move(btime=1000) is None
         assert stockfish.get_best_move(wtime=1000, btime=1000) is None
         assert stockfish.get_best_move(wtime=5 * 60 * 1000, btime=1000) is None
 
-    def test_set_fen_position(self, stockfish):
+    def test_set_fen_position(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"
         )
         assert stockfish.is_move_correct("f4f5") is True
         assert stockfish.is_move_correct("a1c1") is False
 
-    def test_castling(self, stockfish):
+    def test_castling(self, stockfish: Stockfish):
         assert stockfish.is_move_correct("e1g1") is False
         stockfish.set_fen_position(
             "rnbqkbnr/ppp3pp/3ppp2/8/4P3/5N2/PPPPBPPP/RNBQK2R w KQkq - 0 4"
         )
         assert stockfish.is_move_correct("e1g1") is True
 
-    def test_set_fen_position_mate(self, stockfish):
+    def test_set_fen_position_mate(self, stockfish: Stockfish):
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53")
         assert stockfish.get_best_move() is None
         assert stockfish.info == "info depth 0 score mate 0"
 
-    def test_clear_info_after_set_new_fen_position(self, stockfish):
+    def test_clear_info_after_set_new_fen_position(self, stockfish: Stockfish):
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52")
         stockfish.get_best_move()
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53")
@@ -140,7 +140,7 @@ class TestStockfish:
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53", False)
         assert stockfish.info == ""
 
-    def test_set_fen_position_starts_new_game(self, stockfish):
+    def test_set_fen_position_starts_new_game(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "7r/1pr1kppb/2n1p2p/2NpP2P/5PP1/1P6/P6K/R1R2B2 w - - 1 27"
         )
@@ -149,7 +149,7 @@ class TestStockfish:
         stockfish.set_fen_position("3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53")
         assert stockfish.info == ""
 
-    def test_set_fen_position_second_argument(self, stockfish):
+    def test_set_fen_position_second_argument(self, stockfish: Stockfish):
         stockfish.set_depth(16)
         stockfish.set_fen_position(
             "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", True
@@ -166,11 +166,11 @@ class TestStockfish:
         )
         assert stockfish.get_best_move() == "e4e5"
 
-    def test_is_move_correct_first_move(self, stockfish):
+    def test_is_move_correct_first_move(self, stockfish: Stockfish):
         assert stockfish.is_move_correct("e2e1") is False
         assert stockfish.is_move_correct("a2a3") is True
 
-    def test_is_move_correct_not_first_move(self, stockfish):
+    def test_is_move_correct_not_first_move(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         assert stockfish.is_move_correct("e2e1") is False
         assert stockfish.is_move_correct("a2a3") is True
@@ -194,12 +194,12 @@ class TestStockfish:
             "h4g3",
         ],
     )
-    def test_last_info(self, stockfish, value):
+    def test_last_info(self, stockfish: Stockfish, value):
         stockfish.set_fen_position("r6k/6b1/2b1Q3/p6p/1p5q/3P2PP/5r1K/8 w - - 1 31")
         stockfish.get_best_move()
         assert value in stockfish.info
 
-    def test_set_skill_level(self, stockfish):
+    def test_set_skill_level(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/ppp2ppp/3pp3/8/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1"
         )
@@ -229,7 +229,7 @@ class TestStockfish:
         assert stockfish.get_engine_parameters()["UCI_LimitStrength"] == False
         assert not stockfish._on_weaker_setting()
 
-    def test_set_elo_rating(self, stockfish):
+    def test_set_elo_rating(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/ppp2ppp/3pp3/8/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1"
         )
@@ -283,7 +283,7 @@ class TestStockfish:
         assert stockfish._on_weaker_setting()
 
     @pytest.mark.slow
-    def test_resume_full_strength(self, stockfish):
+    def test_resume_full_strength(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "1r1qrbk1/2pb1pp1/p4n1p/P3P3/3P4/NB4BP/6P1/R2QR1K1 b - - 0 1"
         )
@@ -302,7 +302,7 @@ class TestStockfish:
         full_strength_moves = [stockfish.get_best_move() for _ in range(15)]
         assert all(x in best_moves for x in full_strength_moves)
 
-    def test_specific_params(self, stockfish):
+    def test_specific_params(self, stockfish: Stockfish):
         old_parameters = {
             "Debug Log File": "",
             "Contempt": 0,
@@ -350,15 +350,17 @@ class TestStockfish:
             {"UCI_Chess960": "false"},
         ],
     )
-    def test_update_engine_parameters_wrong_type(self, stockfish, parameters):
+    def test_update_engine_parameters_wrong_type(
+        self, stockfish: Stockfish, parameters
+    ):
         with pytest.raises(ValueError):
             stockfish.update_engine_parameters(parameters)
 
-    def test_deprecated_get_parameters(self, stockfish):
+    def test_deprecated_get_parameters(self, stockfish: Stockfish):
         with pytest.raises(ValueError):
             stockfish.get_parameters()
 
-    def test_chess960_position(self, stockfish):
+    def test_chess960_position(self, stockfish: Stockfish):
         assert "KQkq" in stockfish.get_fen_position()
         old_parameters = stockfish.get_engine_parameters()
         expected_parameters = stockfish.get_engine_parameters()
@@ -385,7 +387,7 @@ class TestStockfish:
         assert stockfish.get_evaluation() == {"type": "mate", "value": 2}
         assert stockfish.will_move_be_a_capture("f1g1") is Stockfish.Capture.NO_CAPTURE
 
-    def test_get_board_visual_white(self, stockfish):
+    def test_get_board_visual_white(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])
         if stockfish.get_stockfish_major_version() >= 12:
             expected_result = (
@@ -437,7 +439,7 @@ class TestStockfish:
         # Tests that the previous call to get_board_visual left no remaining lines to be read. This means
         # the second line read after stockfish._put("d") now will be the +---+---+---+ of the new outputted board.
 
-    def test_get_board_visual_black(self, stockfish):
+    def test_get_board_visual_black(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6", "d2d4", "d7d5"])
         if stockfish.get_stockfish_major_version() >= 12:
             expected_result = (
@@ -489,7 +491,7 @@ class TestStockfish:
         # Tests that the previous call to get_board_visual left no remaining lines to be read. This means
         # the second line read after stockfish._put("d") now will be the +---+---+---+ of the new outputted board.
 
-    def test_get_fen_position(self, stockfish):
+    def test_get_fen_position(self, stockfish: Stockfish):
         assert (
             stockfish.get_fen_position()
             == "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
@@ -498,20 +500,20 @@ class TestStockfish:
         stockfish._read_line()  # skip a line
         assert "+---+---+---+" in stockfish._read_line()
 
-    def test_get_fen_position_after_some_moves(self, stockfish):
+    def test_get_fen_position_after_some_moves(self, stockfish: Stockfish):
         stockfish.set_position(["e2e4", "e7e6"])
         assert (
             stockfish.get_fen_position()
             == "rnbqkbnr/pppp1ppp/4p3/8/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2"
         )
 
-    def test_get_stockfish_major_version(self, stockfish):
+    def test_get_stockfish_major_version(self, stockfish: Stockfish):
         assert (
             stockfish.get_stockfish_major_version() in (8, 9, 10, 11, 12, 13, 14, 15)
         ) != stockfish.is_development_build_of_engine()
 
     @pytest.mark.slow
-    def test_get_evaluation_cp(self, stockfish):
+    def test_get_evaluation_cp(self, stockfish: Stockfish):
         stockfish.set_depth(20)
         stockfish.set_fen_position(
             "r4rk1/pppb1p1p/2nbpqp1/8/3P4/3QBN2/PPP1BPPP/R4RK1 w - - 0 11"
@@ -531,32 +533,35 @@ class TestStockfish:
             and evaluation["value"] <= 150
         )
 
-    def test_get_evaluation_checkmate(self, stockfish):
+    def test_get_evaluation_checkmate(self, stockfish: Stockfish):
         stockfish.set_fen_position("1nb1k1n1/pppppppp/8/6r1/5bqK/6r1/8/8 w - - 2 2")
         assert stockfish.get_evaluation() == {"type": "mate", "value": 0}
 
-    def test_get_evaluation_stalemate(self, stockfish):
+    def test_get_evaluation_stalemate(self, stockfish: Stockfish):
         stockfish.set_fen_position("1nb1kqn1/pppppppp/8/6r1/5b1K/6r1/8/8 w - - 2 2")
         assert stockfish.get_evaluation() == {"type": "cp", "value": 0}
         stockfish.set_turn_perspective(not stockfish.get_turn_perspective())
         assert stockfish.get_evaluation() == {"type": "cp", "value": 0}
 
-    def test_get_static_eval(self, stockfish):
+    def test_get_static_eval(self, stockfish: Stockfish):
         stockfish.set_turn_perspective(False)
         stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
-        assert stockfish.get_static_eval() < -3
-        assert isinstance(stockfish.get_static_eval(), float)
+        static_eval_1 = stockfish.get_static_eval()
+        assert isinstance(static_eval_1, float) and static_eval_1 < -3
         stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 b - - 0 1")
-        assert stockfish.get_static_eval() < -3
+        static_eval_2 = stockfish.get_static_eval()
+        assert isinstance(static_eval_2, float) and static_eval_2 < -3
         stockfish.set_turn_perspective()
-        assert stockfish.get_static_eval() > 3
+        static_eval_3 = stockfish.get_static_eval()
+        assert isinstance(static_eval_3, float) and static_eval_3 > 3
         stockfish.set_fen_position("r7/8/8/8/8/5k2/4p3/4K3 w - - 0 1")
-        assert stockfish.get_static_eval() < -3
+        static_eval_4 = stockfish.get_static_eval()
+        assert isinstance(static_eval_4, float) and static_eval_4 < -3
         if stockfish.get_stockfish_major_version() >= 12:
             stockfish.set_fen_position("8/8/8/8/8/4k3/4p3/r3K3 w - - 0 1")
             assert stockfish.get_static_eval() is None
 
-    def test_set_depth(self, stockfish):
+    def test_set_depth(self, stockfish: Stockfish):
         stockfish.set_depth(12)
         assert stockfish._depth == 12
         stockfish.get_best_move()
@@ -567,11 +572,11 @@ class TestStockfish:
         assert "depth 15" in stockfish.info
 
     @pytest.mark.parametrize("depth", ["12", True, 12.1, 0, None])
-    def test_set_depth_raises_type_error(self, stockfish, depth):
+    def test_set_depth_raises_type_error(self, stockfish: Stockfish, depth):
         with pytest.raises(TypeError):
             stockfish.set_depth(depth)
 
-    def test_get_depth(self, stockfish):
+    def test_get_depth(self, stockfish: Stockfish):
         stockfish.set_depth(12)
         assert stockfish.get_depth() == 12
         assert stockfish._depth == 12
@@ -579,24 +584,24 @@ class TestStockfish:
         assert stockfish.get_depth() == 20
         assert stockfish._depth == 20
 
-    def test_set_num_nodes(self, stockfish):
+    def test_set_num_nodes(self, stockfish: Stockfish):
         stockfish.set_num_nodes(100)
         assert stockfish._num_nodes == 100
         stockfish.set_num_nodes()
         assert stockfish._num_nodes == 1000000
 
     @pytest.mark.parametrize("num_nodes", ["100", 100.1, None, True])
-    def test_set_num_nodes_raises_type_error(self, stockfish, num_nodes):
+    def test_set_num_nodes_raises_type_error(self, stockfish: Stockfish, num_nodes):
         with pytest.raises(TypeError):
             stockfish.set_num_nodes(num_nodes)
 
-    def test_get_num_nodes(self, stockfish):
+    def test_get_num_nodes(self, stockfish: Stockfish):
         stockfish.set_num_nodes(100)
         assert stockfish.get_num_nodes() == 100
         stockfish.set_num_nodes()
         assert stockfish.get_num_nodes() == 1000000
 
-    def test_get_best_move_wrong_position(self, stockfish):
+    def test_get_best_move_wrong_position(self, stockfish: Stockfish):
         stockfish.set_depth(2)
         wrong_fen = "3kk3/8/8/8/8/8/8/3KK3 w - - 0 0"
         stockfish.set_fen_position(wrong_fen)
@@ -606,7 +611,7 @@ class TestStockfish:
             "d1c2",
         )
 
-    def test_constructor(self, stockfish):
+    def test_constructor(self, stockfish: Stockfish):
         # Will also use a new stockfish instance in order to test sending
         # params to the constructor.
 
@@ -649,7 +654,7 @@ class TestStockfish:
             else:
                 assert stockfish_2_params[key] == stockfish_1_params[key]
 
-    def test_parameters_functions(self, stockfish):
+    def test_parameters_functions(self, stockfish: Stockfish):
         old_parameters = stockfish.get_engine_parameters()
         stockfish.set_fen_position("4rkr1/4p1p1/8/8/8/8/8/5K1R w H - 0 100")
         assert stockfish.get_best_move() == "f1g1"  # ensures Chess960 param is false.
@@ -692,9 +697,9 @@ class TestStockfish:
         assert stockfish.get_engine_parameters() == old_parameters
         assert stockfish.get_fen_position() == "4rkr1/4p1p1/8/8/8/8/8/5K1R w K - 0 100"
         with pytest.raises(ValueError):
-            stockfish.update_engine_parameters({"Not an existing key", "value"})
+            stockfish.update_engine_parameters({"Not an existing key", "value"})  # type: ignore
 
-    def test_get_top_moves(self, stockfish):
+    def test_get_top_moves(self, stockfish: Stockfish):
         stockfish.set_depth(15)
         stockfish._set_option("MultiPV", 4)
         stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
@@ -715,14 +720,14 @@ class TestStockfish:
             {"Move": "g1h1", "Centipawn": None, "Mate": -1},
         ]
 
-    def test_get_top_moves_mate(self, stockfish):
+    def test_get_top_moves_mate(self, stockfish: Stockfish):
         stockfish.set_depth(10)
         stockfish._set_option("MultiPV", 3)
         stockfish.set_fen_position("8/8/8/8/8/6k1/8/3r2K1 w - - 0 1")
         assert stockfish.get_top_moves() == []
         assert stockfish.get_engine_parameters()["MultiPV"] == 3
 
-    def test_get_top_moves_verbose(self, stockfish):
+    def test_get_top_moves_verbose(self, stockfish: Stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
         assert stockfish.get_top_moves(2, verbose=False) == [
@@ -746,12 +751,12 @@ class TestStockfish:
         if stockfish.does_current_engine_version_have_wdl_option():
             assert "WDL" in moves[0]
 
-    def test_get_top_moves_num_nodes(self, stockfish):
+    def test_get_top_moves_num_nodes(self, stockfish: Stockfish):
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
         moves = stockfish.get_top_moves(2, num_nodes=1000000, verbose=True)
         assert int(moves[0]["Nodes"]) >= 1000000
 
-    def test_get_top_moves_preserve_globals(self, stockfish):
+    def test_get_top_moves_preserve_globals(self, stockfish: Stockfish):
         stockfish._set_option("MultiPV", 4)
         stockfish.set_num_nodes(2000000)
         stockfish.set_fen_position("1rQ1r1k1/5ppp/8/8/1R6/8/2r2PPP/4R1K1 w - - 0 1")
@@ -759,7 +764,7 @@ class TestStockfish:
         assert stockfish.get_num_nodes() == 2000000
         assert stockfish.get_engine_parameters()["MultiPV"] == 4
 
-    def test_get_top_moves_raises_value_error(self, stockfish):
+    def test_get_top_moves_raises_value_error(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         )
@@ -768,7 +773,7 @@ class TestStockfish:
         assert len(stockfish.get_top_moves(2)) == 2
         assert stockfish.get_engine_parameters()["MultiPV"] == 1
 
-    def test_turn_perspective(self, stockfish):
+    def test_turn_perspective(self, stockfish: Stockfish):
         stockfish.set_depth(15)
         stockfish.set_fen_position("8/2q2pk1/4b3/1p6/7P/Q1p3P1/2B2P2/6K1 b - - 3 50")
         assert stockfish.get_turn_perspective()
@@ -781,11 +786,11 @@ class TestStockfish:
         assert moves[0]["Centipawn"] < 0
         assert stockfish.get_evaluation()["value"] < 0
 
-    def test_turn_perspective_raises_type_error(self, stockfish):
+    def test_turn_perspective_raises_type_error(self, stockfish: Stockfish):
         with pytest.raises(TypeError):
-            stockfish.set_turn_perspective("not a bool")
+            stockfish.set_turn_perspective("not a bool")  # type: ignore
 
-    def test_make_moves_from_current_position(self, stockfish):
+    def test_make_moves_from_current_position(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "r1bqkb1r/pppp1ppp/2n2n2/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1"
         )
@@ -826,7 +831,7 @@ class TestStockfish:
                 stockfish.make_moves_from_current_position([invalid_move])
 
     @pytest.mark.slow
-    def test_make_moves_transposition_table_speed(self, stockfish):
+    def test_make_moves_transposition_table_speed(self, stockfish: Stockfish):
         """
         make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
         will reach a new position similar to the current one. Meanwhile, set_fen_position will send this
@@ -848,6 +853,7 @@ class TestStockfish:
         for i in range(5):
             start = default_timer()
             chosen_move = stockfish.get_best_move()
+            assert isinstance(chosen_move, str)
             total_time_calculating_first += default_timer() - start
             positions_considered.append(stockfish.get_fen_position())
             stockfish.make_moves_from_current_position([chosen_move])
@@ -861,13 +867,14 @@ class TestStockfish:
 
         assert total_time_calculating_first < total_time_calculating_second
 
-    def test_get_wdl_stats(self, stockfish):
+    def test_get_wdl_stats(self, stockfish: Stockfish):
         stockfish.set_depth(15)
         stockfish._set_option("MultiPV", 2)
         if stockfish.does_current_engine_version_have_wdl_option():
             stockfish.get_wdl_stats()  # Testing that this doesn't raise a RuntimeError.
             stockfish.set_fen_position("7k/4R3/4P1pp/7N/8/8/1q5q/3K4 w - - 0 1")
             wdl_stats = stockfish.get_wdl_stats()
+            assert isinstance(wdl_stats, list)
             assert wdl_stats[1] > wdl_stats[0] * 7
             assert abs(wdl_stats[0] - wdl_stats[2]) / wdl_stats[0] < 0.1
 
@@ -875,6 +882,7 @@ class TestStockfish:
                 "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
             )
             wdl_stats_2 = stockfish.get_wdl_stats()
+            assert isinstance(wdl_stats_2, list)
             assert wdl_stats_2[1] > wdl_stats_2[0] * 3.5
             assert wdl_stats_2[0] > wdl_stats_2[2] * 1.8
 
@@ -884,7 +892,8 @@ class TestStockfish:
             stockfish.set_fen_position(
                 "rnbqkb1r/pp3ppp/3p1n2/1B2p3/3NP3/2N5/PPP2PPP/R1BQK2R b KQkq - 0 6"
             )
-            assert len(stockfish.get_wdl_stats()) == 3
+            wdl_stats_3 = stockfish.get_wdl_stats()
+            assert isinstance(wdl_stats_3, list) and len(wdl_stats_3) == 3
 
             stockfish.set_fen_position("8/8/8/8/8/3k4/3p4/3K4 w - - 0 1")
             assert stockfish.get_wdl_stats() is None
@@ -896,21 +905,21 @@ class TestStockfish:
             with pytest.raises(RuntimeError):
                 stockfish.get_wdl_stats()
 
-    def test_does_current_engine_version_have_wdl_option(self, stockfish):
+    def test_does_current_engine_version_have_wdl_option(self, stockfish: Stockfish):
         if stockfish.get_stockfish_major_version() <= 11:
             assert not stockfish.does_current_engine_version_have_wdl_option()
             with pytest.raises(RuntimeError):
                 stockfish.get_wdl_stats()
 
     @pytest.mark.slow
-    def test_benchmark_result_with_defaults(self, stockfish):
+    def test_benchmark_result_with_defaults(self, stockfish: Stockfish):
         params = stockfish.BenchmarkParameters()
         result = stockfish.benchmark(params)
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
     @pytest.mark.slow
-    def test_benchmark_result_with_valid_options(self, stockfish):
+    def test_benchmark_result_with_valid_options(self, stockfish: Stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=64, threads=2, limit=1000, limitType="movetime", evalType="classical"
         )
@@ -919,7 +928,7 @@ class TestStockfish:
         assert result.split(" ")[0] == "Nodes/second"
 
     @pytest.mark.slow
-    def test_benchmark_result_with_invalid_options(self, stockfish):
+    def test_benchmark_result_with_invalid_options(self, stockfish: Stockfish):
         params = stockfish.BenchmarkParameters(
             ttSize=2049,
             threads=0,
@@ -933,7 +942,7 @@ class TestStockfish:
         assert result.split(" ")[0] == "Nodes/second"
 
     @pytest.mark.slow
-    def test_benchmark_result_with_invalid_type(self, stockfish):
+    def test_benchmark_result_with_invalid_type(self, stockfish: Stockfish):
         params = {
             "ttSize": 16,
             "threads": 1,
@@ -942,11 +951,11 @@ class TestStockfish:
             "limitType": "depth",
             "evalType": "mixed",
         }
-        result = stockfish.benchmark(params)
+        result = stockfish.benchmark(params)  # type: ignore
         # result should contain the last line of a successful method call
         assert result.split(" ")[0] == "Nodes/second"
 
-    def test_multiple_calls_to_del(self, stockfish):
+    def test_multiple_calls_to_del(self, stockfish: Stockfish):
         assert stockfish._stockfish.poll() is None
         assert not stockfish._has_quit_command_been_sent
         stockfish.__del__()
@@ -956,7 +965,7 @@ class TestStockfish:
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
 
-    def test_multiple_quit_commands(self, stockfish):
+    def test_multiple_quit_commands(self, stockfish: Stockfish):
         # Test multiple quit commands, and include a call to del too. All of
         # them should run without causing some Exception.
         assert stockfish._stockfish.poll() is None
@@ -973,7 +982,7 @@ class TestStockfish:
         assert stockfish._stockfish.poll() is not None
         assert stockfish._has_quit_command_been_sent
 
-    def test_what_is_on_square(self, stockfish):
+    def test_what_is_on_square(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
         )
@@ -998,7 +1007,7 @@ class TestStockfish:
         with pytest.raises(ValueError):
             stockfish.get_what_is_on_square("b9")
 
-    def test_13_return_values_from_what_is_on_square(self, stockfish):
+    def test_13_return_values_from_what_is_on_square(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "rnbq1rk1/ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
         )
@@ -1021,9 +1030,9 @@ class TestStockfish:
         for row in rows:
             for col in cols:
                 val = stockfish.get_what_is_on_square(row + col)
-                assert val == None or val.name in expected_enum_members
+                assert val is None or val.name in expected_enum_members
 
-    def test_will_move_be_a_capture(self, stockfish):
+    def test_will_move_be_a_capture(self, stockfish: Stockfish):
         stockfish.set_fen_position(
             "1nbq1rk1/Ppp1ppbp/5np1/3pP3/8/BPN5/P1PP1PPP/R2QKBNR w KQ d6 0 6"
         )
@@ -1095,7 +1104,7 @@ class TestStockfish:
             "3rk1n1/ppp3pp/8/8/8/8/PPP5/1KR1R3 w - - 0 1",
         ],
     )
-    def test_invalid_fen_king_attacked(self, stockfish, fen):
+    def test_invalid_fen_king_attacked(self, stockfish: Stockfish, fen):
         # Each of these FENs have correct syntax, but
         # involve a king being attacked while it's the opponent's turn.
         old_del_counter = Stockfish._del_counter
@@ -1106,6 +1115,12 @@ class TestStockfish:
         ):
             # Since for that FEN, SF 15 actually outputs a best move without crashing (unlike SF 14 and earlier).
             return
+        if (
+            fen == "2k2q2/8/8/8/8/8/8/2Q2K2 w - - 0 1"
+            and stockfish.get_stockfish_major_version() >= 15
+        ):
+            # Development versions post SF 15 seem to output a bestmove for this fen.
+            return
         assert not stockfish.is_fen_valid(fen)
         assert Stockfish._del_counter == old_del_counter + 2
 
@@ -1114,7 +1129,7 @@ class TestStockfish:
             stockfish.get_evaluation()
 
     @pytest.mark.slow
-    def test_is_fen_valid(self, stockfish):
+    def test_is_fen_valid(self, stockfish: Stockfish):
         old_params = stockfish.get_engine_parameters()
         old_info = stockfish.info
         old_depth = stockfish._depth
@@ -1146,7 +1161,7 @@ class TestStockfish:
         assert stockfish._depth == old_depth
         assert stockfish.get_fen_position() == old_fen
 
-    def test_send_quit_command(self, stockfish):
+    def test_send_quit_command(self, stockfish: Stockfish):
         assert stockfish._stockfish.poll() is None
         old_del_counter = Stockfish._del_counter
         stockfish.send_quit_command()
@@ -1155,13 +1170,13 @@ class TestStockfish:
         assert stockfish._stockfish.poll() is not None
         assert Stockfish._del_counter == old_del_counter + 1
 
-    def test_set_option(self, stockfish):
+    def test_set_option(self, stockfish: Stockfish):
         stockfish._set_option("MultiPV", 3)
         assert stockfish.get_engine_parameters()["MultiPV"] == 3
         stockfish._set_option("MultiPV", 6, False)  # update_parameters_attribute
         assert stockfish.get_engine_parameters()["MultiPV"] == 3
 
-    def test_pick(self, stockfish):
+    def test_pick(self, stockfish: Stockfish):
         info = "info depth 10 seldepth 15 multipv 1 score cp -677 wdl 0 0 1000"
         line = info.split(" ")
         assert stockfish._pick(line, "depth") == "10"

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1390,8 +1390,8 @@ class TestStockfish:
         )
         assert stockfish.get_num_pieces(rank_range=[7, 8], file_range=["e", "H"]) == 5
 
-    def test_get_parameters(self, stockfish):
-        params = stockfish.get_parameters()
+    def test_get_engine_parameters(self, stockfish):
+        params = stockfish.get_engine_parameters()
         params.update({"Skill Level": 10})
         assert params["Skill Level"] == 10
         assert stockfish._parameters["Skill Level"] == 20

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -957,17 +957,22 @@ class TestStockfish:
                 == expected_outputs_2[i]
             )
 
-        input_test_moves_3 = (
-            "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4 b3xd4 b3d4 Nb3xd4".split()
-        )
-        expected_outputs_3 = (
-            "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4  b3d4  b3d4 b3d4".split()
-        )
+        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbxd4 Nfxd4 b3xd4 b3d4".split()
+        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4  f5d4  b3d4  b3d4".split()
 
         for i in range(len(input_test_moves_3)):
             assert (
                 stockfish.convert_human_notation_to_sf_notation(input_test_moves_3[i])
                 == expected_outputs_3[i]
+            )
+
+        input_test_moves_4 = "Nb3xd4 c5c6 c6".split()
+        expected_outputs_4 = "b3d4   c5c6 c5c6".split()
+
+        for i in range(len(input_test_moves_4)):
+            assert (
+                stockfish.convert_human_notation_to_sf_notation(input_test_moves_4[i])
+                == expected_outputs_4[i]
             )
 
         wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3 nbd4".split()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -953,7 +953,7 @@ class TestStockfish:
             )
 
         input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7 nd6+ Nxe7 0-0  00  ".split()
-        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7 b5d6 f5e7 e1g1 e1g1".split()
+        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7 f5d6 f5e7 e1g1 e1g1".split()
 
         for i in range(len(input_test_moves_2)):
             assert (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -1083,49 +1083,34 @@ class TestStockfish:
                 )
                 == 2
             )
-            assert (
-                stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
-                    specific_rank=i + 1,
-                    pieces_to_count=["P"],
-                )
-                == (1 if i + 1 == 2 else 0)
-            )
-            assert (
-                stockfish.get_num_pieces(
-                    specific_file=chr(ord("a") + i),
-                    specific_rank=8 - i,
-                    pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
-                )
-                == (1 if 8 - i == 7 else 0)
-            )
+            assert stockfish.get_num_pieces(
+                specific_file=chr(ord("a") + i),
+                specific_rank=i + 1,
+                pieces_to_count=["P"],
+            ) == (1 if i + 1 == 2 else 0)
+            assert stockfish.get_num_pieces(
+                specific_file=chr(ord("a") + i),
+                specific_rank=8 - i,
+                pieces_to_count=[Stockfish.Piece.BLACK_PAWN],
+            ) == (1 if 8 - i == 7 else 0)
 
             for j in range(len(back_rank_pieces)):
                 i_j_in_sync = (i == j) or (i == 7 - j and i not in [3, 4])
-                assert (
-                    stockfish.get_num_pieces(
-                        specific_file=chr(ord("a") + i),
-                        pieces_to_count=[
-                            back_rank_pieces[j],
-                            back_rank_pieces[j].lower(),
-                        ],
-                    )
-                    == (2 if i_j_in_sync else 0)
-                )
-                assert (
-                    stockfish.get_num_pieces(
-                        specific_file=chr(ord("a") + i),
-                        pieces_to_count=[back_rank_pieces[j]],
-                    )
-                    == (1 if i_j_in_sync else 0)
-                )
-                assert (
-                    stockfish.get_num_pieces(
-                        specific_file=chr(ord("a") + i),
-                        pieces_to_count=[back_rank_pieces[j].lower()],
-                    )
-                    == (1 if i_j_in_sync else 0)
-                )
+                assert stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    pieces_to_count=[
+                        back_rank_pieces[j],
+                        back_rank_pieces[j].lower(),
+                    ],
+                ) == (2 if i_j_in_sync else 0)
+                assert stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    pieces_to_count=[back_rank_pieces[j]],
+                ) == (1 if i_j_in_sync else 0)
+                assert stockfish.get_num_pieces(
+                    specific_file=chr(ord("a") + i),
+                    pieces_to_count=[back_rank_pieces[j].lower()],
+                ) == (1 if i_j_in_sync else 0)
 
         with pytest.raises(ValueError):
             stockfish.get_num_pieces(specific_rank=-1)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -104,7 +104,7 @@ class TestStockfish:
 
         stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/r7/4K3 b - - 11 52")
         stockfish.get_best_move()
-        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53", False)
+        stockfish.set_fen_position("8/8/8/6pp/8/4k1PP/8/r3K3 w - - 12 53")
         assert stockfish.info == ""
 
     def test_set_fen_position_starts_new_game(self, stockfish):
@@ -116,20 +116,21 @@ class TestStockfish:
         stockfish.set_fen_position("3kn3/p5rp/1p3p2/3B4/3P1P2/2P5/1P3K2/8 w - - 0 53")
         assert stockfish.info == ""
 
-    def test_set_fen_position_second_argument(self, stockfish):
+    def test_set_fen_position_ucinewgame(self, stockfish):
         stockfish.set_depth(16)
+        stockfish.send_ucinewgame_command()
         stockfish.set_fen_position(
-            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", True
+            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1"
         )
         assert stockfish.get_best_move() == "e4e5"
 
         stockfish.set_fen_position(
-            "rnbqk2r/pppp1ppp/3bpn2/4P3/3P4/2N5/PPP2PPP/R1BQKBNR b KQkq - 0 1", False
+            "rnbqk2r/pppp1ppp/3bpn2/4P3/3P4/2N5/PPP2PPP/R1BQKBNR b KQkq - 0 1"
         )
         assert stockfish.get_best_move() == "d6e7"
 
         stockfish.set_fen_position(
-            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1", False
+            "rnbqk2r/pppp1ppp/3bpn2/8/3PP3/2N5/PPP2PPP/R1BQKBNR w KQkq - 0 1"
         )
         assert stockfish.get_best_move() == "e4e5"
 
@@ -622,14 +623,8 @@ class TestStockfish:
 
     def test_make_moves_transposition_table_speed(self, stockfish):
         """
-        make_moves_from_current_position won't send the "ucinewgame" token to Stockfish, since it
-        will reach a new position similar to the current one. Meanwhile, set_fen_position will send this
-        token (unless the user specifies otherwise), since it could be going to a completely new position.
-
-        A big effect of sending this token is that it resets SF's transposition table. If the
-        new position is similar to the current one, this will affect SF's speed. This function tests
-        that make_moves_from_current_position doesn't reset the transposition table, by verifying SF is faster in
-        evaluating a consecutive set of positions when the make_moves_from_current_position function is used.
+        Test if not sending the ucinewgame token allows SF to calculate a bit faster,
+        since it can use data in its TT from previous calculations.
         """
 
         stockfish.set_depth(16)
@@ -648,6 +643,7 @@ class TestStockfish:
 
         total_time_calculating_second = 0.0
         for i in range(len(positions_considered)):
+            stockfish.send_ucinewgame_command()
             stockfish.set_fen_position(positions_considered[i])
             start = default_timer()
             stockfish.get_best_move()

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -966,7 +966,7 @@ class TestStockfish:
                 == expected_outputs_3[i]
             )
 
-        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO".split()
+        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO Bd5 Nxg3".split()
 
         for move in wrong_test_moves:
             with pytest.raises(ValueError):

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -941,7 +941,7 @@ class TestStockfish:
 
     def test_convert_human_notation_to_sf_notation(self, stockfish):
         stockfish.set_fen_position(
-            "rnbbk1nr/pPP1pp1p/1p2B3/1NPpPN1Q/3p1B2/4Pq2/P4PPP/R3K2R w KQkq d6 0 2"
+            "rnbbk1nr/pPP1pp1p/1p2B3/2PpPN1Q/3p1B2/1N2Pq2/P4PPP/R3K2R w KQkq d6 0 2"
         )
         input_test_moves_1 = "exd6 Bxc8 cxd8Q+ cxd8R bxc8=Q bxc8Q bxa8=N cxd6".split()
         expected_outputs_1 = "e5d6 e6c8 c7d8Q  c7d8R b7c8Q  b7c8Q b7a8N  c5d6".split()
@@ -952,8 +952,8 @@ class TestStockfish:
                 == expected_outputs_1[i]
             )
 
-        input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7 Nbd6+ nfd6 Nxe7 0-0  00  ".split()
-        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7 b5d6  f5d6 f5e7 e1g1 e1g1".split()
+        input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7 nd6+ Nxe7 0-0  00  ".split()
+        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7 b5d6 f5e7 e1g1 e1g1".split()
 
         for i in range(len(input_test_moves_2)):
             assert (
@@ -961,8 +961,8 @@ class TestStockfish:
                 == expected_outputs_2[i]
             )
 
-        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O".split()
-        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1".split()
+        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O  nbd4 Nfxd4".split()
+        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1 b3d4 f5d4 ".split()
 
         for i in range(len(input_test_moves_3)):
             assert (

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -938,20 +938,40 @@ class TestStockfish:
         stockfish.__del__()
         assert stockfish._stockfish.poll() is not None
         assert Stockfish._del_counter == old_del_counter + 1
-    
+
     def test_convert_human_notation_to_sf_notation(self, stockfish):
-        stockfish.set_fen_position("rnbbk1nr/pPP1pp1p/1p2B3/1NPpP2Q/3p1B2/4Pq2/P4PPP/R3K2R w KQkq d6 0 2")
-        input_test_moves_1 = "exd6 Bxc8 cxd8Q+ cxd8R bxc8=Q bxc8Q bxa8=N cxd6 Qxf7 Qxf7#".split()
-        expected_outputs_1 = "e5d6 e6c8 c7d8q  c7d8r b7c8q  b7c8q b7a8n  c5d6 h5f7 h5f7".split()
-        
+        stockfish.set_fen_position(
+            "rnbbk1nr/pPP1pp1p/1p2B3/1NPpPN1Q/3p1B2/4Pq2/P4PPP/R3K2R w KQkq d6 0 2"
+        )
+        input_test_moves_1 = "exd6 Bxc8 cxd8Q+ cxd8R bxc8=Q bxc8Q bxa8=N cxd6".split()
+        expected_outputs_1 = "e5d6 e6c8 c7d8Q  c7d8R b7c8Q  b7c8Q b7a8N  c5d6".split()
+
         for i in range(len(input_test_moves_1)):
-            assert stockfish.convert_human_notation_to_sf_notation(input_test_moves_1[i]) == expected_outputs_1[i]
-        
-        input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7"
-        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7"
-        
-        wrong_test_moves = "ed bxc8 bxa8"
-        
-        
-        
-        
+            assert (
+                stockfish.convert_human_notation_to_sf_notation(input_test_moves_1[i])
+                == expected_outputs_1[i]
+            )
+
+        input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7 Nbd6+ nfd6 Nxe7 0-0  00  ".split()
+        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7 b5d6  f5d6 f5e7 e1g1 e1g1".split()
+
+        for i in range(len(input_test_moves_2)):
+            assert (
+                stockfish.convert_human_notation_to_sf_notation(input_test_moves_2[i])
+                == expected_outputs_2[i]
+            )
+
+        input_test_moves_3 = "Qxf7 Qxf7# e1g1 h1f1 O-O".split()
+        expected_outputs_3 = "h5f7 h5f7  e1g1 h1f1 e1g1".split()
+
+        for i in range(len(input_test_moves_3)):
+            assert (
+                stockfish.convert_human_notation_to_sf_notation(input_test_moves_3[i])
+                == expected_outputs_3[i]
+            )
+
+        wrong_test_moves = "ed bxc8 bxa8 0-0-0 OOO".split()
+
+        for move in wrong_test_moves:
+            with pytest.raises(ValueError):
+                stockfish.convert_human_notation_to_sf_notation(move)

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -861,7 +861,6 @@ class TestStockfish:
         "fen",
         [
             "2k2q2/8/8/8/8/8/8/2Q2K2 w - - 0 1",
-            "8/8/8/3k4/3K4/8/8/8 b - - 0 1",
             "1q2nB2/pP1k2KP/NN1Q1qP1/8/1P1p4/4p1br/3R4/6n1 w - - 0 1",
             "3rk1n1/ppp3pp/8/8/8/8/PPP5/1KR1R3 w - - 0 1",
         ],
@@ -871,12 +870,6 @@ class TestStockfish:
         # involve a king being attacked while it's the opponent's turn.
         old_del_counter = Stockfish._del_counter
         assert Stockfish._is_fen_syntax_valid(fen)
-        if fen == "8/8/8/3k4/3K4/8/8/8 b - - 0 1" and not (
-            10 < stockfish.get_stockfish_major_version() < 15
-        ):
-            # Since for that FEN, SF 15+ and 10- actually output
-            # a best move without crashing (unlike SFs 11 to 14).
-            return
         assert not stockfish.is_fen_valid(fen)
         assert Stockfish._del_counter == old_del_counter + 2
 

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -904,20 +904,39 @@ class TestStockfish:
             "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - 0 8",
             "4k3/8/4K3/8/8/8/8/8 w - - 10 50",
             "r1b1kb1r/ppp2ppp/3q4/8/P2Q4/8/1PP2PPP/RNB2RK1 w kq - 8 15",
+            "4k3/8/4K3/8/8/8/8/8 w - - 99 50",
         ]
+        correct_fens.extend([None] * 12)
         invalid_syntax_fens = [
             "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK b kq - 0 8",
             "rnbqkb1r/pppp1ppp/4pn2/8/2PP4/8/PP2PPPP/RNBQKBNR w KQkq - 3",
             "rn1q1rk1/pbppbppp/1p2pn2/8/2PP4/5NP1/PP2PPBP/RNBQ1RK1 w w - 5 7",
             "4k3/8/4K3/71/8/8/8/8 w - - 10 50",
+            "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2R2 b kq - 0 8",
+            "r1bQ1b1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - 0 8",
+            "4k3/8/4K3/8/8/8/8/8 w - - 100 50",
+            "4k3/8/4K3/8/8/8/8/8 w - - 101 50",
+            "4k3/8/4K3/8/8/8/8/8 w - - -1 50",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 0",
+            "r1b1kb1r/ppp2ppp/3q4/8/P2Q4/8/1PP2PPP/RNB2RK1 w kq - - 8 15",
+            "r1b1kb1r/ppp2ppp/3q4/8/P2Q4/8/1PP2PPP/RNB2RK1 w kq 8 15",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR W KQkq - 0 1",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR - KQkq - 0 1",
+            "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - - 8",
+            "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - 0 -",
+            "r1bQkb1r/ppp2ppp/2p5/4Pn2/8/5N2/PPP2PPP/RNB2RK1 b kq - -1 8",
         ]
+        assert len(correct_fens) == len(invalid_syntax_fens)
         for correct_fen, invalid_syntax_fen in zip(correct_fens, invalid_syntax_fens):
             old_del_counter = Stockfish._del_counter
-            assert stockfish.is_fen_valid(correct_fen)
+            if correct_fen is not None:
+                assert stockfish.is_fen_valid(correct_fen)
+                assert stockfish._is_fen_syntax_valid(correct_fen)
             assert not stockfish.is_fen_valid(invalid_syntax_fen)
-            assert stockfish._is_fen_syntax_valid(correct_fen)
             assert not stockfish._is_fen_syntax_valid(invalid_syntax_fen)
-            assert Stockfish._del_counter == old_del_counter + 2
+            assert Stockfish._del_counter == old_del_counter + (
+                2 if correct_fen is not None else 0
+            )
 
         time.sleep(2.0)
         assert stockfish._stockfish.poll() is None
@@ -985,10 +1004,9 @@ class TestStockfish:
         "fen",
         [
             "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b - - 10 20"
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b - - 10 20",
         ],
     )
-
     def test_get_num_pieces(self, stockfish, fen):
         stockfish.set_fen_position(fen)
         assert stockfish.get_num_pieces() == 32

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -938,3 +938,20 @@ class TestStockfish:
         stockfish.__del__()
         assert stockfish._stockfish.poll() is not None
         assert Stockfish._del_counter == old_del_counter + 1
+    
+    def test_convert_human_notation_to_sf_notation(self, stockfish):
+        stockfish.set_fen_position("rnbbk1nr/pPP1pp1p/1p2B3/1NPpP2Q/3p1B2/4Pq2/P4PPP/R3K2R w KQkq d6 0 2")
+        input_test_moves_1 = "exd6 Bxc8 cxd8Q+ cxd8R bxc8=Q bxc8Q bxa8=N cxd6 Qxf7 Qxf7#".split()
+        expected_outputs_1 = "e5d6 e6c8 c7d8q  c7d8r b7c8q  b7c8q b7a8n  c5d6 h5f7 h5f7".split()
+        
+        for i in range(len(input_test_moves_1)):
+            assert stockfish.convert_human_notation_to_sf_notation(input_test_moves_1[i]) == expected_outputs_1[i]
+        
+        input_test_moves_2 = "gxf3 g2xf3 Bxf7+ Bxf7"
+        expected_outputs_2 = "g2f3 g2f3  e6f7  e6f7"
+        
+        wrong_test_moves = "ed bxc8 bxa8"
+        
+        
+        
+        

--- a/tests/stockfish/test_models.py
+++ b/tests/stockfish/test_models.py
@@ -12,13 +12,7 @@ class TestStockfish:
 
     def test_get_best_move_first_move(self, stockfish):
         best_move = stockfish.get_best_move()
-        assert best_move in (
-            "e2e3",
-            "e2e4",
-            "g1f3",
-            "b1c3",
-            "d2d4",
-        )
+        assert best_move in ("e2e3", "e2e4", "g1f3", "b1c3", "d2d4")
 
     def test_get_best_move_time_first_move(self, stockfish):
         best_move = stockfish.get_best_move_time(1000)
@@ -457,11 +451,7 @@ class TestStockfish:
         stockfish.set_depth(2)
         wrong_fen = "3kk3/8/8/8/8/8/8/3KK3 w - - 0 0"
         stockfish.set_fen_position(wrong_fen)
-        assert stockfish.get_best_move() in (
-            "d1e2",
-            "d1c1",
-            "d1c2",
-        )
+        assert stockfish.get_best_move() in ("d1e2", "d1c1", "d1c2")
 
     def test_constructor(self, stockfish):
         # Will also use a new stockfish instance in order to test sending
@@ -1102,8 +1092,7 @@ class TestStockfish:
 
             assert stockfish.get_num_pieces(file_range=a_file_plus_i) == 4
             assert stockfish.get_num_pieces(
-                file_range=a_file_plus_i,
-                rank_range=[8 - i, 8 - i],
+                file_range=a_file_plus_i, rank_range=[8 - i, 8 - i]
             ) == (0 if 3 <= 8 - i <= 6 else 1)
 
             assert (
@@ -1128,14 +1117,10 @@ class TestStockfish:
                 i_j_in_sync = (i == j) or (i == 7 - j and i not in [3, 4])
                 assert stockfish.get_num_pieces(
                     file_range=a_file_plus_i,
-                    pieces_to_count=[
-                        back_rank_pieces[j],
-                        back_rank_pieces[j].lower(),
-                    ],
+                    pieces_to_count=[back_rank_pieces[j], back_rank_pieces[j].lower()],
                 ) == (2 if i_j_in_sync else 0)
                 assert stockfish.get_num_pieces(
-                    file_range=a_file_plus_i,
-                    pieces_to_count=[back_rank_pieces[j]],
+                    file_range=a_file_plus_i, pieces_to_count=[back_rank_pieces[j]]
                 ) == (1 if i_j_in_sync else 0)
                 assert stockfish.get_num_pieces(
                     file_range=a_file_plus_i,
@@ -1176,3 +1161,9 @@ class TestStockfish:
             stockfish.get_num_pieces(rank_range=[4, 6], pieces_to_count=["P", "p"]) == 4
         )
         assert stockfish.get_num_pieces(rank_range=[7, 8], file_range=["e", "H"]) == 5
+
+    def test_get_parameters(self, stockfish):
+        params = stockfish.get_parameters()
+        params.update({"Skill Level": 10})
+        assert params["Skill Level"] == 10
+        assert stockfish._parameters["Skill Level"] == 20


### PR DESCRIPTION
Note - since this PR is quite big, please merge the other PRs into master first. I'll then resolve any conflicts for this PR.

Closes #110 

This PR allows the user to convert "human-style" notation into the notation format that Stockfish uses.

Thanks to @FalcoGer for providing the code for this feature in issue 110. I've refined it a bit and added some tests, but most of the credit should go to them.

Besides this, the PR also:

- Doesn't send the "ucinewgame" command to the Stockfish engine, when setting a new position. I noticed that doing this frequently can end up being a large bottleneck (as Stockfish has to reset its transposition table each time). Instead, I've made a separate function which the user can call to send this command, if they want to.
- Updates the readme to explain the get_top_moves and make_moves_from_current_position functions, as well as the Stockfish.Piece enum a bit.
- Adds a function that lets the user find the number of pieces. If desired, the user can specify to only count the number of pieces in a certain range of file(s) and/or row(s). They also have the option of only counting certain pieces.
- Modifies the _is_fen_syntax_valid function. Some changes include fixing a bug with splitting up the fields (use fen.split() instead of regexMatch.groups()), and adding checks for more types of invalid FENs (such as the halfmove clock field being >= 2x greater than the fullmove counter).