### PR TITLE
Added more default stockfish parameters

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -39,9 +39,17 @@ class Stockfish:
             "Move Overhead": 10,
             "Minimum Thinking Time": 20,
             "Slow Mover": 100,
+            "nodestime": 0,
+            "Use NNUE": "false",
             "UCI_Chess960": "false",
+            "UCI_AnalyseMode": "false",
             "UCI_LimitStrength": "false",
             "UCI_Elo": 1350,
+            "UCI_ShowWDL": "false",
+            "SyzygyPath": "",
+            "SyzygyProbeDepth": 1,
+            "Syzygy50MoveRule": "true",
+            "SyzygyProbeLimit": 7,
         }
         self._path = path
         self._stockfish = subprocess.Popen(


### PR DESCRIPTION
PR #89 added a check that will raise a `ValueError` if the new parameter isn't in the default parameters:
```python
    for key in new_param_values:
        if key not in self._parameters:
            raise ValueError(f"'{key}' is not a key that exists.")
```
But the `_DEFAULT_STOCKFISH_PARAMS` is missing quite a few parameters, such as `Use NNUE`, this makes it impossible to use such parameters. Code to reproduce the problem:
```python
Stockfish("stockfish_15_x64_avx2.exe", parameters={"Use NNUE": "true"})
```
This PR attempts to fix this problem by adding all the available parameters to the default list:
```diff
self._DEFAULT_STOCKFISH_PARAMS = {
    "Debug Log File": "",
    "Contempt": 0,
    "Min Split Depth": 0,
    "Threads": 1,
    "Ponder": "false",
    "Hash": 16,
    "MultiPV": 1,
    "Skill Level": 20,
    "Move Overhead": 10,
    "Minimum Thinking Time": 20,
    "Slow Mover": 100,
+    "nodestime": 0,
+    "Use NNUE": "false",
    "UCI_Chess960": "false",
+    "UCI_AnalyseMode": "false",
    "UCI_LimitStrength": "false",
    "UCI_Elo": 1350,
+    "UCI_ShowWDL": "false",
+    "SyzygyPath": "",
+    "SyzygyProbeDepth": 1,
+    "Syzygy50MoveRule": "true",
+    "SyzygyProbeLimit": 7,
}
```
Although, there is a parameter called `EvalFile` (used for NNUE), its default value is something like `nn-6877cd24400e.nnue`, which varies from version to version, and hadn't been added in this PR.

This could have been done better by making an available parameter list instead of using the `self._parameters`, or by not checking at all, but I didn't want to make any big changes.