### PR TITLE
Get top moves at each depth

### DIFF
--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -25,7 +25,10 @@ class Stockfish:
     # Used in test_models: will count how many times the del function is called.
 
     def __init__(
-        self, path: str = "stockfish", depth: int = 15, parameters: dict = None
+        self,
+        path: str = "stockfish",
+        depth: int = 15,
+        parameters: Optional[dict] = None,
     ) -> None:
         self._DEFAULT_STOCKFISH_PARAMS = {
             "Debug Log File": "",
@@ -324,7 +327,9 @@ class Stockfish:
             {"UCI_LimitStrength": "true", "UCI_Elo": elo_rating}
         )
 
-    def get_best_move(self, wtime: int = None, btime: int = None) -> Optional[str]:
+    def get_best_move(
+        self, wtime: Optional[int] = None, btime: Optional[int] = None
+    ) -> Optional[str]:
         """Returns best move with current position on the board.
         wtime and btime arguments influence the search only if provided.
 
@@ -622,8 +627,12 @@ class Stockfish:
                 # both moves has no mate, compare the depth first than centipawn
                 if self.depth == other.depth:
                     if self.cp == other.cp:
+                        if self.seldepth is None or other.seldepth is None:
+                            raise RuntimeError("None value when it should be an int.")
                         return self.seldepth > other.seldepth
                     else:
+                        if self.cp is None or other.cp is None:
+                            raise RuntimeError("None value when it should be an int.")
                         return self.cp > other.cp
                 else:
                     return self.depth > other.depth
@@ -651,7 +660,9 @@ class Stockfish:
             return not self.__gt__(other)
 
         # equal move, by "move", not by score/evaluation
-        def __eq__(self, other: Stockfish.TopMove) -> bool:
+        def __eq__(self, other: object) -> bool:
+            if not isinstance(other, Stockfish.TopMove):
+                return False
             return self.move == other.move
 
     def generate_top_moves(
@@ -738,8 +749,9 @@ class Stockfish:
                                     top_moves.insert(0, move)
                                     break
                             else:
-                                raise ValueError(f"Stockfish returned the best move: {best_move}, but it's not in the list")
-                            
+                                raise ValueError(
+                                    f"Stockfish returned the best move: {best_move}, but it's not in the list"
+                                )
 
                         yield top_moves[:num_top_moves]
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -715,6 +715,7 @@ class Stockfish:
 
                     # yield the top moves once the current depth changed, the current depth might be smaller than the old depth
                     if move.depth != current_depth:
+                        current_depth = move.depth
                         top_moves.sort(reverse=True)
                         yield top_moves[:num_top_moves]
 

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -657,7 +657,7 @@ class Stockfish:
     def generate_top_moves(
         self, num_top_moves: int = 5
     ) -> Generator[List[TopMove], None, None]:
-        """Returns a generator that yield top moves in the position at every depth
+        """Returns a generator that yields top moves in the position at each depth
 
         Args:
             num_top_moves:
@@ -665,7 +665,7 @@ class Stockfish:
                 those many legal moves.
 
         Returns:
-            A generator that yield top moves in the position at every depth.
+            A generator that yields top moves in the position at each depth.
 
             The evaluation could be stopped early by calling Generator.close();
                 this however will take some time for stockfish to stop.
@@ -674,7 +674,7 @@ class Stockfish:
             a list of `Stockfish.TopMove` instead, and the score (cp/mate) is relative
             to which side is playing instead of absolute like `get_top_moves`.
 
-            The score is either `cp` or `mate`; higher `cp` is better, positive `mate`
+            The score is either `cp` or `mate`; a higher `cp` is better, a positive `mate`
             is winning and vice versa.
 
             If there are no moves in the position, an empty list is returned.

--- a/stockfish/models.py
+++ b/stockfish/models.py
@@ -729,9 +729,25 @@ class Stockfish:
                     else:
                         # sort the list once again
                         top_moves.sort(reverse=True)
+
+                        # if the move at index 0 is not the best move returned by stockfish
+                        if best_move != top_moves[0].move:
+                            for move in top_moves:
+                                if best_move == move.move:
+                                    top_moves.remove(move)
+                                    top_moves.insert(0, move)
+                                    break
+                            else:
+                                raise ValueError(f"Stockfish returned the best move: {best_move}, but it's not in the list")
+                            
+
                         yield top_moves[:num_top_moves]
 
                     break
+
+        except BaseException as e:
+            raise e from e
+
         finally:
             # stockfish has not returned the best move, but the generator was signaled to close
             if not foundBestMove:


### PR DESCRIPTION
Added the `generate_top_moves` method which returns a generator that yields top moves in the position at every depth.

This helps evaluate the position at a high depth and update the interface simultaneously. The evaluation could be stopped by calling `Generator.close()`.

### Breaking changes:
- The list returned by the generator is now a list of `Stockfish.TopMove` class instead of a list of dict. This is necessary for sorting the list of top moves without writing a custom sort algorithm.
- The centipawn and mate values are now relative to the turn, they are the same values as returned from stockfish.

### Notice:
- Top moves returned while evaluating are sorted by mate first, then depth, then centipawn.
- The depth, while evaluating, could go backward, e.g. the next depth could be lower than the previous depth.
- Stopping the evaluation can take some time, it sends the `stop` command to stockfish and waits for the `bestmove` to be returned to continue execution.

### Example usage:
Simple usage:
```python
for top_moves in stockfish.generate_top_moves():
    best_move = top_moves[0]
    print(f"Best move at depth {best_move.depth}: {best_move.move}")
```
Stop the evaluation early:
```python
gen = stockfish.generate_top_moves()
try:
    while True:
        top_moves = next(gen)
        best_move = top_moves[0]
        print(f"Best move at depth {best_move.depth}: {best_move.move}")

        if best_move.depth == 5:
            gen.close() # stop the evaluation
            break

except StopIteration:
    print("Finished evaluation")
```

With this simple method added, you can do some pretty neat stuff like this:
![ezgif-3-ea1d484d39](https://user-images.githubusercontent.com/17585270/202457958-0d4d14a2-cec9-4a66-bf16-69640ce3e799.gif)
